### PR TITLE
Add nightly source json to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.package.outputs.artifact }}
+      - name: Update AltStore source
+        id: update_source
+        run: |
+          NIGHTLY_BUILD=1 python update_json.py
       - name: Nightly Release
         uses: andelf/nightly-release@v1
         env:
@@ -141,3 +145,4 @@ jobs:
             This is a nightly release [created automatically with GitHub Actions workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}).
           files: |
             ${{ needs.package.outputs.artifact }}
+            apps_nightly.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,8 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Download a Build Artifact
         uses: actions/download-artifact@v4
         with:
@@ -135,7 +137,7 @@ jobs:
       - name: Update AltStore source
         id: update_source
         run: |
-          NIGHTLY_BUILD=1 python update_json.py
+          NIGHTLY_LINK="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" python update_json.py
       - name: Nightly Release
         uses: andelf/nightly-release@v1
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ packages/
 *.xccheckout
 xcuserdata
 Resources/Frameworks/OpenSSL.framework
+apps_nightly.json

--- a/apps_nightly.json
+++ b/apps_nightly.json
@@ -1,6 +1,6 @@
 {
-  "name": "LiveContainer",
-  "identifier": "com.livecontainer.source",
+  "name": "LiveContainer Nightly",
+  "identifier": "com.livecontainer.source.nightly",
   "website": "https://github.com/LiveContainer/LiveContainer",
   "subtitle": "LiveContainer Nightly official AltStore Source.",
   "description": "This is the official AltStore Source for LiveContainer Nightly.\n\n Run iOS apps without actually installing them!",

--- a/apps_nightly.json
+++ b/apps_nightly.json
@@ -1,16 +1,16 @@
 {
-  "name": "LiveContainer Nightly",
+  "name": "LiveContainer (nightly)",
   "identifier": "com.livecontainer.source.nightly",
   "website": "https://github.com/LiveContainer/LiveContainer",
-  "subtitle": "LiveContainer Nightly official AltStore Source.",
-  "description": "This is the official AltStore Source for LiveContainer Nightly.\n\n Run iOS apps without actually installing them!",
+  "subtitle": "LiveContainer (nightly) official AltStore Source.",
+  "description": "This is the official AltStore Source for LiveContainer (nightly).\n\n Run iOS apps without actually installing them!",
   "tintColor": "#0784FC",
   "iconURL": "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/Resources/AppIcon76x76.png",
   "headerURL": "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/screenshots/header.png",
   "apps": [
     {
       "beta": false,
-      "name": "LiveContainer",
+      "name": "LiveContainer (nightly)",
       "bundleIdentifier": "com.kdt.livecontainer",
       "developerName": "LiveContainer Team",
       "subtitle": "Run iOS apps without actually installing them!",

--- a/apps_nightly.json
+++ b/apps_nightly.json
@@ -1,0 +1,90 @@
+{
+  "name": "LiveContainer",
+  "identifier": "com.livecontainer.source",
+  "website": "https://github.com/LiveContainer/LiveContainer",
+  "subtitle": "LiveContainer Nightly official AltStore Source.",
+  "description": "This is the official AltStore Source for LiveContainer Nightly.\n\n Run iOS apps without actually installing them!",
+  "tintColor": "#0784FC",
+  "iconURL": "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/Resources/AppIcon76x76.png",
+  "headerURL": "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/screenshots/header.png",
+  "apps": [
+    {
+      "beta": false,
+      "name": "LiveContainer",
+      "bundleIdentifier": "com.kdt.livecontainer",
+      "developerName": "LiveContainer Team",
+      "subtitle": "Run iOS apps without actually installing them!",
+      "version": "3.4.50",
+      "versionDate": "2025-04-26",
+      "versionDescription": "This is a nightly release [created automatically with GitHub Actions workflow](https://github.com/LiveContainer/LiveContainer/actions/runs/14679205373/attempts/1).",
+      "downloadURL": "https://github.com/LiveContainer/LiveContainer/releases/download/nightly/LiveContainer.ipa",
+      "localizedDescription": "Run iOS apps without actually installing them!",
+      "iconURL": "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/Resources/AppIcon76x76.png",
+      "tintColor": "#0784FC",
+      "category": "utilities",
+      "size": 2785962,
+      "screenshotURLs": [
+        "https://raw.githubusercontent.com/LiveContainer/LiveContainer/main/screenshots/1.png"
+      ],
+      "appPermissions": {
+        "entitlements": [
+          "application-identifier",
+          "com.apple.security.application-groups",
+          "get-task-allow",
+          "keychain-access-groups",
+          "com.apple.developer.kernel.extended-virtual-addressing",
+          "com.apple.developer.kernel.increased-memory-limit"
+        ],
+        "privacy": {
+          "LSRequiresIPhoneOS": "The guest app is requesting for this permission.",
+          "NFCReaderUsageDescription": "The guest app is requesting for this permission.",
+          "NSAppleMusicUsageDescription": "The guest app is requesting for this permission.",
+          "NSBluetoothAlwaysUsageDescription": "The guest app is requesting for this permission.",
+          "NSBluetoothPeripheralUsageDescription": "The guest app is requesting for this permission.",
+          "NSCalendarsFullAccessUsageDescription": "The guest app is requesting for this permission.",
+          "NSCalendarsWriteOnlyAccessUsageDescription": "The guest app is requesting for this permission.",
+          "NSCameraUsageDescription": "The guest app is requesting for this permission.",
+          "NSContactsUsageDescription": "The guest app is requesting for this permission.",
+          "NSFaceIDUsageDescription": "The guest app is requesting for this permission.",
+          "NSFallDetectionUsageDescription": "The guest app is requesting for this permission.",
+          "NSGKFriendListUsageDescription": "The guest app is requesting for this permission.",
+          "NSHealthClinicalHealthRecordsShareUsageDescription": "The guest app is requesting for this permission.",
+          "NSHealthRequiredReadAuthorizationTypeIdentifiers": "The guest app is requesting for this permission.",
+          "NSHomeKitUsageDescription": "The guest app is requesting for this permission.",
+          "NSIdentityUsageDescription": "The guest app is requesting for this permission.",
+          "NSLocalNetworkUsageDescription": "The guest app is requesting for this permission.",
+          "NSLocationDefaultAccuracyReduced": "The guest app is requesting for this permission.",
+          "NSLocationTemporaryUsageDescriptionDictionary": "The guest app is requesting for this permission.",
+          "NSLocationUsageDescription": "The guest app is requesting for this permission.",
+          "NSLocationWhenInUseUsageDescription": "The guest app is requesting for this permission.",
+          "NSMicrophoneUsageDescription": "The guest app is requesting for this permission.",
+          "NSMotionUsageDescription": "The guest app is requesting for this permission.",
+          "NSNearbyInteractionAllowOnceUsageDescription": "The guest app is requesting for this permission.",
+          "NSNearbyInteractionUsageDescription": "The guest app is requesting for this permission.",
+          "NSPhotoLibraryAddUsageDescription": "The guest app is requesting for this permission.",
+          "NSPhotoLibraryUsageDescription": "The guest app is requesting for this permission.",
+          "NSRemindersFullAccessUsageDescription": "The guest app is requesting for this permission.",
+          "NSSensorKitUsageDescription": "The guest app is requesting for this permission.",
+          "NSSiriUsageDescription": "The guest app is requesting for this permission.",
+          "NSSpeechRecognitionUsageDescription": "The guest app is requesting for this permission.",
+          "NSUserTrackingUsageDescription": "The guest app is requesting for this permission.",
+          "SBAppUsesLocalNotifications": "The guest app is requesting for this permission.",
+          "UIApplicationSceneManifest": "The guest app is requesting for this permission.",
+          "NSHealthUpdateUsageDescription": "The guest app is requesting for this permission.",
+          "NSHealthShareUsageDescription": "The guest app is requesting for this permission.",
+          "NSLocationAlwaysAndWhenInUseUsageDescription": "The guest app is requesting for this permission."
+        }
+      },
+      "versions": [
+        {
+          "version": "3.4.50",
+          "date": "2025-04-26",
+          "localizedDescription": "This is a nightly release [created automatically with GitHub Actions workflow](https://github.com/LiveContainer/LiveContainer/actions/runs/14679205373/attempts/1).",
+          "downloadURL": "https://github.com/LiveContainer/LiveContainer/releases/download/nightly/LiveContainer.ipa",
+          "size": 2785962
+        }
+      ]
+    }
+  ],
+  "news": []
+}

--- a/update_json.py
+++ b/update_json.py
@@ -154,8 +154,8 @@ def update_json_file_nightly(json_file, nightly_release):
     date_obj = datetime.strptime(version_date, "%Y-%m-%dT%H:%M:%SZ")
     version_date = date_obj.strftime("%Y-%m-%d")
 
-    nightly_link = environ.get("NIGHTLY_BUILD")
-    description = "This is a nightly release [created automatically with GitHub Actions workflow]({nightly_link})"
+    nightly_link = os.environ.get("NIGHTLY_LINK")
+    description = f"This is a nightly release [created automatically with GitHub Actions workflow]({nightly_link})"
     description = prepare_description(description)
 
     assets = nightly_release.get("assets", [])
@@ -202,7 +202,7 @@ def update_json_file_nightly(json_file, nightly_release):
 
 def main():
     repo_url = "LiveContainer/LiveContainer"
-    is_nightly = "NIGHTLY_BUILD" in environ
+    is_nightly = "NIGHTLY_LINK" in os.environ
 
     try:
         fetched_data_latest = fetch_latest_release(repo_url)

--- a/update_json.py
+++ b/update_json.py
@@ -154,7 +154,8 @@ def update_json_file_nightly(json_file, nightly_release):
     date_obj = datetime.strptime(version_date, "%Y-%m-%dT%H:%M:%SZ")
     version_date = date_obj.strftime("%Y-%m-%d")
 
-    description = nightly_release["body"]
+    nightly_link = environ.get("NIGHTLY_BUILD")
+    description = "This is a nightly release [created automatically with GitHub Actions workflow]({nightly_link})"
     description = prepare_description(description)
 
     assets = nightly_release.get("assets", [])
@@ -201,7 +202,7 @@ def update_json_file_nightly(json_file, nightly_release):
 
 def main():
     repo_url = "LiveContainer/LiveContainer"
-    is_nightly = "NIGHTLY_BUILD" in os.environ
+    is_nightly = "NIGHTLY_BUILD" in environ
 
     try:
         fetched_data_latest = fetch_latest_release(repo_url)


### PR DESCRIPTION
As an enhancement to #156, this PR makes it possible to update LiveContainer nightly within SideStore/AltStore by updating [apps_nightly.json](https://github.com/LiveContainer/LiveContainer/releases/download/nightly/apps_nightly.json) alongside the nightly `.ipa` file. Thanks @hugeBlack (we're on the team anyways lol) for this idea.