### PR TITLE
Updates to ReadMe

### DIFF
--- a/LiveContainerSwiftUI/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/LCSettingsView.swift
@@ -16,7 +16,7 @@ enum PatchChoice {
 
 enum JITEnablerType : Int {
     case SideJITServer = 0
-    case StkiJIT = 1
+    case StikDebug = 1
     case JITStreamerEBLegacy = 2
     case StikJITLC = 3
     case SideStore = 4
@@ -173,7 +173,7 @@ struct LCSettingsView: View {
                     }
                     Picker(selection: $JITEnabler) {
                         Text("SideJITServer/JITStreamer 2.0").tag(JITEnablerType.SideJITServer)
-                        Text("StikJIT (StandAlone)").tag(JITEnablerType.StkiJIT)
+                        Text("StikDebug (Standalone)").tag(JITEnablerType.StikDebug)
                         Text("StikJIT (Another LiveContainer)").tag(JITEnablerType.StikJITLC)
                         Text("SideStore").tag(JITEnablerType.SideStore)
                         Text("JitStreamer-EB (Relaunch)").tag(JITEnablerType.JITStreamerEBLegacy)

--- a/LiveContainerSwiftUI/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/LCSettingsView.swift
@@ -16,7 +16,7 @@ enum PatchChoice {
 
 enum JITEnablerType : Int {
     case SideJITServer = 0
-    case StikDebug = 1
+    case StkiJIT = 1
     case JITStreamerEBLegacy = 2
     case StikJITLC = 3
     case SideStore = 4
@@ -173,7 +173,7 @@ struct LCSettingsView: View {
                     }
                     Picker(selection: $JITEnabler) {
                         Text("SideJITServer/JITStreamer 2.0").tag(JITEnablerType.SideJITServer)
-                        Text("StikDebug (Standalone)").tag(JITEnablerType.StikDebug)
+                        Text("StikJIT (StandAlone)").tag(JITEnablerType.StkiJIT)
                         Text("StikJIT (Another LiveContainer)").tag(JITEnablerType.StikJITLC)
                         Text("SideStore").tag(JITEnablerType.SideStore)
                         Text("JitStreamer-EB (Relaunch)").tag(JITEnablerType.JITStreamerEBLegacy)

--- a/README.md
+++ b/README.md
@@ -62,10 +62,6 @@ If you reinstall SideStore/AltStore using AltServer, you will need to go through
 >[!Note]
 If you update or reinstall SideStore/AltStore, you'll need to reapply the patch. Re-patch is not needed when you refresh your store.
 
-### With JIT (requires SideStore)
-- Tap the play icon, it will jump to SideStore and exit.
-- In SideStore, hold down LiveContainer and tap `Enable JIT`. If you have SideStore build supporting JIT URL scheme, it jumps back to LiveContainer with JIT enabled and the guest app is ready to use.
-
 ### Installing Apps
 - Open LiveContainer, tap the plus icon in the upper right hand corner and select IPA files to install.
 - Choose the app you want to open in the next launch.

--- a/README.md
+++ b/README.md
@@ -20,27 +20,37 @@
 >[!Note]
 It’s recommended to follow the following steps to set up JIT-Less mode for using LiveContainer without JIT. If you encounter any issues, please review #265 first before reporting them.
 
-## Usage
-Requires AltStore or SideStore
-- Download methods: [AltStore Source](https://tinyurl.com/LCAltStoreClassic), [SideStore Source](https://tinyurl.com/LCSideStore), the latest IPA [here](https://github.com/LiveContainer/LiveContainer/releases/latest), or the latest nightly IPA [here](https://github.com/LiveContainer/LiveContainer/releases/tag/nightly)
-- It is recommended to setup JIT-Less mode, in which LiveContainer signs your apps with certificate from SideStore/AltStore, see the instructions below.
-- Open LiveContainer, tap the plus icon in the upper right hand corner and select IPA files to install.
-- Choose the app you want to open in the next launch.
-- You can long-press the app to manage it.
+## Download
+
+- Download methods:
+- Stable:
+
+  [AltSource (raw)](https://raw.githubusercontent.com/LiveContainer/LiveContainer/refs/heads/main/apps.json) ([Add to AltStore](https://tinyurl.com/LCAltStoreClassic), [Add to SideStore](https://tinyurl.com/LCSideStore)), [IPA download](https://github.com/LiveContainer/LiveContainer/releases/latest)
+
+- Nightly:
+
+  [AltSource (raw)](https://raw.githubusercontent.com/LiveContainer/LiveContainer/refs/heads/hbdev/apps_nightly.json) ([Add to AltStore](https://tinyurl.com/LCAltStoreClassic-N), [Add to SideStore](https://tinyurl.com/LCSideStore-N)), [IPA download](https://github.com/LiveContainer/LiveContainer/releases/tag/nightly)
+- It is recommended to setup JIT-Less mode, in which LiveContainer signs your apps with your certificate from AltStore/SideStore (see the instructions below).
+
+## Installation
+
 
 ### JIT-Less mode (Without JIT)
-Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from SideStore or AltStore. 
+Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from SideStore or AltStore.
+
 >[!Note] 
 JIT-Less mode does not mean you can't enable JIT for your apps. Instead, it means JIT is not required to launch an app. If you want to use JIT, see the instructions below in "JIT Support" section. 
 If something goes wrong, please check "JIT-Less Mode Diagnose" for more information.
 
-#### Method 1 (Requires SideStore 0.6.2-20250420.25+)
+#### Method 1 (Requires SideStore 0.6.2-nightly+ \[recommended])
 - Open Settings in LiveContainer 
 - Tap "Import Certificate from SideStore"
 - SideStore will be opened and ask if you want to export the certificate. If you don't see the prompt, keep SideStore open in the background and tap "Import Certificate from SideStore" again.
 - Press "Export"
 - Tap "JIT-Less Mode Diagnose" and tap "Test JIT-Less Mode"
 - If it says "JIT-Less Mode Test Passed", you are good to go!
+>[!Note] 
+If you reinstall SideStore/AltStore using AltServer, you will need to go through these steps again or risk needing to reinstall the app.
 
 #### Method 2 (Requires AltStore/SideStore)
 - Open Settings in LiveContainer, tap "Patch SideStore/AltStore", and the app will switch to SideStore/AltStore to reinstall it with the tweak applied. If you use AltWidget, select "Keep Extension."
@@ -54,6 +64,11 @@ Note: If you update or reinstall SideStore/AltStore, you'll need to reapply the 
 ### With JIT (requires SideStore)
 - Tap the play icon, it will jump to SideStore and exit.
 - In SideStore, hold down LiveContainer and tap `Enable JIT`. If you have SideStore build supporting JIT URL scheme, it jumps back to LiveContainer with JIT enabled and the guest app is ready to use.
+
+### Installing Apps
+- Open LiveContainer, tap the plus icon in the upper right hand corner and select IPA files to install.
+- Choose the app you want to open in the next launch.
+- You can long-press the app to manage it.
 
 ### Add to Home Screen
 Long press the app and you will see 2 ways to add your app to home screen:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ If you reinstall SideStore/AltStore using AltServer, you will need to go through
 - Install your app via the "Apps" tab.
 - Tap the run icon, it will attempt to restart LiveContainer with guest app loaded.
 
-Note: If you update or reinstall SideStore/AltStore, you'll need to reapply the patch. Re-patch is not needed when you refresh your store.
+>[!Note]
+If you update or reinstall SideStore/AltStore, you'll need to reapply the patch. Re-patch is not needed when you refresh your store.
 
 ### With JIT (requires SideStore)
 - Tap the play icon, it will jump to SideStore and exit.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It’s recommended to follow the following steps to set up JIT-Less mode for usi
 ## Installation
 
 
-### JIT-Less mode (Without JIT)
+### JIT-Less mode (Without JIT \[recommended])
 Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from SideStore or AltStore.
 
 >[!Note] 

--- a/README.md
+++ b/README.md
@@ -20,29 +20,33 @@
 >[!Note]
 It’s recommended to follow the following steps to set up JIT-Less mode for using LiveContainer without JIT. If you encounter any issues, please review #265 first before reporting them.
 
-## Download
 
-- Download methods:
-- Stable:
+# Installation
 
+## Requirements
+
+- iOS/iPadOS 15+
+- AltStore 2.0+ / SideStore 0.6.0+
+
+## Download Mthods
+### Stable:
   [AltSource (raw)](https://raw.githubusercontent.com/LiveContainer/LiveContainer/refs/heads/main/apps.json) ([Add to AltStore](https://tinyurl.com/LCAltStoreClassic), [Add to SideStore](https://tinyurl.com/LCSideStore)), [IPA download](https://github.com/LiveContainer/LiveContainer/releases/latest)
 
-- Nightly:
-
+### Nightly:
   [AltSource (raw)](https://raw.githubusercontent.com/LiveContainer/LiveContainer/refs/heads/hbdev/apps_nightly.json) ([Add to AltStore](https://tinyurl.com/LCAltStoreClassic-N), [Add to SideStore](https://tinyurl.com/LCSideStore-N)), [IPA download](https://github.com/LiveContainer/LiveContainer/releases/tag/nightly)
+
 - It is recommended to setup JIT-Less mode, in which LiveContainer signs your apps with your certificate from AltStore/SideStore (see the instructions below).
 
 ## Installation
 
-
 ### JIT-Less mode (Without JIT \[recommended])
-These steps can be bypassed if you don't mind enabling JIT for your app every time, but it is not recommended. Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from SideStore or AltStore.
+These steps can be bypassed if you don't mind enabling JIT for your app every time, but it is not recommended. Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from AltStore/SideStore.
 
 >[!Note] 
 JIT-Less mode does not mean you can't enable JIT for your apps. Instead, it means JIT is not required to launch an app. If you want to use JIT, see the instructions below in "JIT Support" section. 
 If something goes wrong, please check "JIT-Less Mode Diagnose" for more information.
 
-#### Method 1 (Requires SideStore 0.6.2-nightly+ \[recommended])
+#### Method 1 (Requires AltStore 2.2.1+ / SideStore 0.6.2-nightly+ \[recommended])
 - Open Settings in LiveContainer 
 - Tap "Import Certificate from SideStore"
 - SideStore will be opened and ask if you want to export the certificate. If you don't see the prompt, keep SideStore open in the background and tap "Import Certificate from SideStore" again.
@@ -50,17 +54,17 @@ If something goes wrong, please check "JIT-Less Mode Diagnose" for more informat
 - Tap "JIT-Less Mode Diagnose" and tap "Test JIT-Less Mode"
 - If it says "JIT-Less Mode Test Passed", you are good to go!
 >[!Note] 
-If you reinstall SideStore/AltStore using AltServer, you will need to go through these steps again or risk needing to reinstall the app.
+If you reinstall AltStore/SideStore using AltServer, you will need to go through these steps again or risk needing to reinstall the app.
 
 #### Method 2 (Requires AltStore/SideStore)
-- Open Settings in LiveContainer, tap "Patch SideStore/AltStore", and the app will switch to SideStore/AltStore to reinstall it with the tweak applied. If you use AltWidget, select "Keep Extension."
-- Wait for the installation to finish, then **reopen SideStore/AltStore**.
+- Open Settings in LiveContainer, tap "Patch AltStore/SideStore", and the app will switch to AltStore/SideStore to reinstall it with the tweak applied. If you use AltWidget, select "Keep Extension."
+- Wait for the installation to finish, then **reopen AltStore/SideStore**.
 - Return to LiveContainer and press "Test JIT-Less Mode." If it says "Test Passed," JIT-less mode is ready.
 - Install your app via the "Apps" tab.
 - Tap the run icon, it will attempt to restart LiveContainer with guest app loaded.
 
 >[!Note]
-If you update or reinstall SideStore/AltStore, you'll need to reapply the patch. Re-patch is not needed when you refresh your store.
+If you update or reinstall AltStore/SideStore, you'll need to reapply the patch. Re-patch is not needed when you refresh your store.
 
 ### Installing Apps
 - Open LiveContainer, tap the plus icon in the upper right hand corner and select IPA files to install.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It’s recommended to follow the following steps to set up JIT-Less mode for usi
 
 
 ### JIT-Less mode (Without JIT \[recommended])
-Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from SideStore or AltStore.
+These steps can be bypassed if you don't mind enabling JIT for your app every time, but it is not recommended. Without JIT, guest apps need to be codesigned, which requires retrieving the certificate and password from SideStore or AltStore.
 
 >[!Note] 
 JIT-Less mode does not mean you can't enable JIT for your apps. Instead, it means JIT is not required to launch an app. If you want to use JIT, see the instructions below in "JIT Support" section. 


### PR DESCRIPTION
Some updates regarding installation in the ReadMe, adding nightly links, and keeping it closer to the website. (Corresponds with another PR for the website which was already merged)

Some updates to the repo about page that couldn't be addressed in a PR that I would suggest: Fix the grammar to "Run iOS apps without actually installing them!", and set the website link to https://livecontainer.github.io/ because that exists now.