### PR TITLE
Add Support for ADP certificate with custom App Group

### DIFF
--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -141,18 +141,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		172CA8B42D9D74A700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				CODE_OF_CONDUCT.md,
-				CONTRIBUTING.md,
-				fishhook.c,
-				fishhook.podspec,
-				LICENSE,
-				README.md,
-			);
-			target = 17DCE99C2C7067EC00731D42 /* LiveContainer */;
-		};
 		172CA8BD2D9D74B700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -177,19 +165,26 @@
 			);
 			target = 174140392D9C0D0000F3F928 /* TweakLoader */;
 		};
+		185E49412DE4D9F60087954A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				fishhook.c,
+			);
+			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
+		};
+		18E3F6AD2DE706D300B2FEDB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				LCMachOUtils.m,
+			);
+			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
+		};
 		E1292AF72DCA3A660065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = E1292AE42DCA3A660065E12D /* LiveProcess */;
-		};
-		E1292C122DCA43D50065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				fishhook.c,
-			);
-			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
 		};
 		E1292C202DCA48F00065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -238,8 +233,8 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		172CA8992D9D72C300CF6989 /* Resources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (172CA8BD2D9D74B700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 172CA8C32D9D76AD00CF6989 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Resources; sourceTree = "<group>"; };
-		172CA8AD2D9D741F00CF6989 /* fishhook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (172CA8B42D9D74A700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, E1292C122DCA43D50065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = fishhook; sourceTree = "<group>"; };
-		17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = LiveContainerSwiftUI; sourceTree = "<group>"; };
+		172CA8AD2D9D741F00CF6989 /* fishhook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (185E49412DE4D9F60087954A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = fishhook; sourceTree = "<group>"; };
+		17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (18E3F6AD2DE706D300B2FEDB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LiveContainerSwiftUI; sourceTree = "<group>"; };
 		174140162D9C0C1B00F3F928 /* TweakLoader */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (174140F52D9C1C9B00F3F928 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 174140F62D9C1C9B00F3F928 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TweakLoader; sourceTree = "<group>"; };
 		174140552D9C0D6D00F3F928 /* ZSign */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ZSign; sourceTree = "<group>"; };
 		1741409C2D9C0EDD00F3F928 /* AltStoreTweak */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = AltStoreTweak; sourceTree = "<group>"; };
@@ -1255,7 +1250,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = 5HH3RFW8P5;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Resources/Frameworks",
@@ -1300,9 +1295,9 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = entitlements.xml;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Resources/Frameworks",
@@ -1410,10 +1405,10 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = LiveProcess/LiveProcess.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				EXECUTABLE_EXTENSION = "";
 				EXECUTABLE_NAME = LiveProcess_PleaseDoNotShortenTheExecutableNameBecauseItIsUsedToReserveSpaceForOverwritingThankYou;
@@ -1496,11 +1491,13 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kdt.livecontainer.LiveContainerShared;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = debugging;
+				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -1560,7 +1557,7 @@
 				17413FC02D9C0BAE00F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		174140402D9C0D0000F3F928 /* Build configuration list for PBXNativeTarget "TweakLoader" */ = {
 			isa = XCConfigurationList;
@@ -1569,7 +1566,7 @@
 				174140422D9C0D0000F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		1741405A2D9C0D6D00F3F928 /* Build configuration list for PBXNativeTarget "ZSign" */ = {
 			isa = XCConfigurationList;
@@ -1578,7 +1575,7 @@
 				1741405C2D9C0D6D00F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		174140A12D9C0EDE00F3F928 /* Build configuration list for PBXNativeTarget "AltStoreTweak" */ = {
 			isa = XCConfigurationList;
@@ -1587,7 +1584,7 @@
 				174140A32D9C0EDE00F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		174140B32D9C0F4100F3F928 /* Build configuration list for PBXNativeTarget "TestJITLess" */ = {
 			isa = XCConfigurationList;
@@ -1596,7 +1593,7 @@
 				174140B52D9C0F4100F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		17DCE9982C7067EC00731D42 /* Build configuration list for PBXProject "LiveContainer" */ = {
 			isa = XCConfigurationList;
@@ -1605,7 +1602,7 @@
 				17DCE9D52C7067ED00731D42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		17DCE9DA2C7067ED00731D42 /* Build configuration list for PBXNativeTarget "LiveContainer" */ = {
 			isa = XCConfigurationList;
@@ -1614,7 +1611,7 @@
 				17DCE9DC2C7067ED00731D42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		E1292AF42DCA3A660065E12D /* Build configuration list for PBXNativeTarget "LiveProcess" */ = {
 			isa = XCConfigurationList;
@@ -1623,7 +1620,7 @@
 				E1292AF62DCA3A660065E12D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		E1292BF12DCA3B670065E12D /* Build configuration list for PBXNativeTarget "LiveContainerShared" */ = {
 			isa = XCConfigurationList;
@@ -1632,7 +1629,7 @@
 				E1292BEE2DCA3B670065E12D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -141,6 +141,18 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		172CA8B42D9D74A700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				CODE_OF_CONDUCT.md,
+				CONTRIBUTING.md,
+				fishhook.c,
+				fishhook.podspec,
+				LICENSE,
+				README.md,
+			);
+			target = 17DCE99C2C7067EC00731D42 /* LiveContainer */;
+		};
 		172CA8BD2D9D74B700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -165,14 +177,7 @@
 			);
 			target = 174140392D9C0D0000F3F928 /* TweakLoader */;
 		};
-		185E49412DE4D9F60087954A /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				fishhook.c,
-			);
-			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
-		};
-		18E3F6AD2DE706D300B2FEDB /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		18226A552DE8D87800531E9D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				LCMachOUtils.m,
@@ -185,6 +190,13 @@
 				Info.plist,
 			);
 			target = E1292AE42DCA3A660065E12D /* LiveProcess */;
+		};
+		E1292C122DCA43D50065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				fishhook.c,
+			);
+			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
 		};
 		E1292C202DCA48F00065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -233,8 +245,8 @@
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		172CA8992D9D72C300CF6989 /* Resources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (172CA8BD2D9D74B700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 172CA8C32D9D76AD00CF6989 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Resources; sourceTree = "<group>"; };
-		172CA8AD2D9D741F00CF6989 /* fishhook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (185E49412DE4D9F60087954A /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = fishhook; sourceTree = "<group>"; };
-		17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (18E3F6AD2DE706D300B2FEDB /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LiveContainerSwiftUI; sourceTree = "<group>"; };
+		172CA8AD2D9D741F00CF6989 /* fishhook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (172CA8B42D9D74A700CF6989 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, E1292C122DCA43D50065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = fishhook; sourceTree = "<group>"; };
+		17413FB62D9C0BAE00F3F928 /* LiveContainerSwiftUI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (18226A552DE8D87800531E9D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LiveContainerSwiftUI; sourceTree = "<group>"; };
 		174140162D9C0C1B00F3F928 /* TweakLoader */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (174140F52D9C1C9B00F3F928 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 174140F62D9C1C9B00F3F928 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TweakLoader; sourceTree = "<group>"; };
 		174140552D9C0D6D00F3F928 /* ZSign */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ZSign; sourceTree = "<group>"; };
 		1741409C2D9C0EDD00F3F928 /* AltStoreTweak */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = AltStoreTweak; sourceTree = "<group>"; };
@@ -1250,7 +1262,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5HH3RFW8P5;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Resources/Frameworks",
@@ -1295,9 +1307,9 @@
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_ENTITLEMENTS = entitlements.xml;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Resources/Frameworks",
@@ -1405,10 +1417,10 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = LiveProcess/LiveProcess.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				EXECUTABLE_EXTENSION = "";
 				EXECUTABLE_NAME = LiveProcess_PleaseDoNotShortenTheExecutableNameBecauseItIsUsedToReserveSpaceForOverwritingThankYou;
@@ -1491,13 +1503,11 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kdt.livecontainer.LiveContainerShared;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = debugging;
-				SWIFT_COMPILATION_MODE = singlefile;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 6.0;
@@ -1557,7 +1567,7 @@
 				17413FC02D9C0BAE00F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		174140402D9C0D0000F3F928 /* Build configuration list for PBXNativeTarget "TweakLoader" */ = {
 			isa = XCConfigurationList;
@@ -1566,7 +1576,7 @@
 				174140422D9C0D0000F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		1741405A2D9C0D6D00F3F928 /* Build configuration list for PBXNativeTarget "ZSign" */ = {
 			isa = XCConfigurationList;
@@ -1575,7 +1585,7 @@
 				1741405C2D9C0D6D00F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		174140A12D9C0EDE00F3F928 /* Build configuration list for PBXNativeTarget "AltStoreTweak" */ = {
 			isa = XCConfigurationList;
@@ -1584,7 +1594,7 @@
 				174140A32D9C0EDE00F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		174140B32D9C0F4100F3F928 /* Build configuration list for PBXNativeTarget "TestJITLess" */ = {
 			isa = XCConfigurationList;
@@ -1593,7 +1603,7 @@
 				174140B52D9C0F4100F3F928 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		17DCE9982C7067EC00731D42 /* Build configuration list for PBXProject "LiveContainer" */ = {
 			isa = XCConfigurationList;
@@ -1602,7 +1612,7 @@
 				17DCE9D52C7067ED00731D42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		17DCE9DA2C7067ED00731D42 /* Build configuration list for PBXNativeTarget "LiveContainer" */ = {
 			isa = XCConfigurationList;
@@ -1611,7 +1621,7 @@
 				17DCE9DC2C7067ED00731D42 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		E1292AF42DCA3A660065E12D /* Build configuration list for PBXNativeTarget "LiveProcess" */ = {
 			isa = XCConfigurationList;
@@ -1620,7 +1630,7 @@
 				E1292AF62DCA3A660065E12D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 		E1292BF12DCA3B670065E12D /* Build configuration list for PBXNativeTarget "LiveContainerShared" */ = {
 			isa = XCConfigurationList;
@@ -1629,7 +1639,7 @@
 				E1292BEE2DCA3B670065E12D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/LiveContainer/LCSharedUtils.m
+++ b/LiveContainer/LCSharedUtils.m
@@ -5,6 +5,7 @@
 extern NSUserDefaults *lcUserDefaults;
 extern NSString *lcAppUrlScheme;
 extern NSBundle *lcMainBundle;
+extern NSString* getLCEntitlementXML(void);
 
 @implementation LCSharedUtils
 
@@ -74,6 +75,22 @@ extern NSBundle *lcMainBundle;
             appGroupID = group;
             return;
         }
+        
+        // if no possibleAppGroup is found, we detect app group from entitlement file
+        NSString *entitlementXML = getLCEntitlementXML();
+        if (!entitlementXML) {
+            return;
+        }
+        NSData *xmlData = [entitlementXML dataUsingEncoding:NSUTF8StringEncoding];
+        id entitlementDict = [NSPropertyListSerialization propertyListWithData:xmlData options:0 format:NULL error:NULL];
+        if (![entitlementDict isKindOfClass:[NSDictionary class]]) {
+            return;
+        }
+        NSArray<NSString *> *appGroups = entitlementDict[@"com.apple.security.application-groups"];
+        if (!appGroups) {
+            return;
+        }
+        appGroupID = [appGroups firstObject];
     });
     return appGroupID;
 }

--- a/LiveContainer/LCSharedUtils.m
+++ b/LiveContainer/LCSharedUtils.m
@@ -77,6 +77,12 @@ extern NSString* getLCEntitlementXML(void);
         }
         
         // if no possibleAppGroup is found, we detect app group from entitlement file
+        // Cache app group after importing cert so we don't have to analyze executable every launch
+        NSString *cached = [lcUserDefaults objectForKey:@"LCAppGroupID"];
+        if (cached) {
+            appGroupID = cached;
+            return;
+        }
         NSString *entitlementXML = getLCEntitlementXML();
         if (!entitlementXML) {
             return;
@@ -87,7 +93,7 @@ extern NSString* getLCEntitlementXML(void);
             return;
         }
         NSArray<NSString *> *appGroups = entitlementDict[@"com.apple.security.application-groups"];
-        if (!appGroups) {
+        if (!appGroups || ![appGroups firstObject]) {
             return;
         }
         appGroupID = [appGroups firstObject];

--- a/LiveContainerSwiftUI/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/LCAppSettingsView.swift
@@ -78,7 +78,7 @@ struct LCAppSettingsView : View{
                 }
                 
                 if !model.uiIsShared {
-                    if LCUtils.isAppGroupAltStoreLike() {
+                    if LCUtils.isAppGroupAltStoreLike() || LCUtils.store() == .ADP {
                         Button("lc.appSettings.toSharedApp".loc) {
                             Task { await moveToAppGroup()}
                         }

--- a/LiveContainerSwiftUI/LCJITLessDiagnoseView.swift
+++ b/LiveContainerSwiftUI/LCJITLessDiagnoseView.swift
@@ -357,7 +357,7 @@ struct LCJITLessDiagnoseView : View {
             return;
         }
         
-        if !sharedModel.certificateImported && !LCUtils.isAppGroupAltStoreLike() {
+        if !sharedModel.certificateImported && !LCUtils.isAppGroupAltStoreLike() && store != .ADP {
             errorInfo = "lc.settings.unsupportedInstallMethod".loc
             errorShow = true
             return;

--- a/LiveContainerSwiftUI/LCJITLessDiagnoseView.swift
+++ b/LiveContainerSwiftUI/LCJITLessDiagnoseView.swift
@@ -351,7 +351,7 @@ struct LCJITLessDiagnoseView : View {
     }
     
     func testJITLessMode() {
-        if !sharedModel.certificateImported && store == .ADP {
+        if store == .ADP && !certificateDataFound {
             errorInfo = "lc.settings.error.certNotImported".loc
             errorShow = true
             return;

--- a/LiveContainerSwiftUI/LCJITLessDiagnoseView.swift
+++ b/LiveContainerSwiftUI/LCJITLessDiagnoseView.swift
@@ -202,18 +202,23 @@ struct LCJITLessDiagnoseView : View {
                             } else if store == .SideStore {
                                 Text("SideStore")
                                     .foregroundStyle(.gray)
-                            } else {
+                            } else if store == .ADP {
+                                Text("lc.common.ADP".loc)
+                                    .foregroundStyle(.gray)
+                            }else {
                                 Text("lc.common.unknown")
                                     .foregroundStyle(.gray)
                             }
+                            
                         }
-                        HStack {
-                            Text("lc.jitlessDiag.patchDetected".loc)
-                            Spacer()
-                            Text(isPatchDetected ? "lc.common.yes".loc : "lc.common.no".loc)
-                                .foregroundStyle(isPatchDetected ? .green : .red)
+                        if store != .ADP && store != .Unknown {
+                            HStack {
+                                Text("lc.jitlessDiag.patchDetected".loc)
+                                Spacer()
+                                Text(isPatchDetected ? "lc.common.yes".loc : "lc.common.no".loc)
+                                    .foregroundStyle(isPatchDetected ? .green : .red)
+                            }
                         }
-                        
                         HStack {
                             Text("lc.jitlessDiag.certDataFound".loc)
                             Spacer()
@@ -346,6 +351,12 @@ struct LCJITLessDiagnoseView : View {
     }
     
     func testJITLessMode() {
+        if !sharedModel.certificateImported && store == .ADP {
+            errorInfo = "lc.settings.error.certNotImported".loc
+            errorShow = true
+            return;
+        }
+        
         if !sharedModel.certificateImported && !LCUtils.isAppGroupAltStoreLike() {
             errorInfo = "lc.settings.unsupportedInstallMethod".loc
             errorShow = true

--- a/LiveContainerSwiftUI/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/LCSettingsView.swift
@@ -649,6 +649,7 @@ struct LCSettingsView: View {
             UserDefaults.standard.set(true, forKey: "LCCertificateImported")
             sharedModel.certificateImported = true
         }
+        UserDefaults.standard.set(LCUtils.appGroupID(), forKey: "LCAppGroupID")
     }
     
     func importCertificateFromSideStore() async {
@@ -687,6 +688,7 @@ struct LCSettingsView: View {
             UserDefaults.standard.set(nil, forKey: "LCCertificateData")
             sharedModel.certificateImported = false
         }
+        UserDefaults.standard.set(nil, forKey: "LCAppGroupID")
     }
     
     func nukeSideStore() async {

--- a/LiveContainerSwiftUI/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/LCSettingsView.swift
@@ -642,7 +642,7 @@ struct LCSettingsView: View {
             LCUtils.appGroupUserDefault.set(certificateData, forKey: "LCCertificateData")
             LCUtils.appGroupUserDefault.set(certificatePassword, forKey: "LCCertificatePassword")
             LCUtils.appGroupUserDefault.set(NSDate.now, forKey: "LCCertificateUpdateDate")
-            sharedModel.certificateImported = sharedModel.certificateImported
+            certificateDataFound = true
         } else {
             UserDefaults.standard.set(certificatePassword, forKey: "LCCertificatePassword")
             UserDefaults.standard.set(certificateData, forKey: "LCCertificateData")
@@ -680,7 +680,7 @@ struct LCSettingsView: View {
             LCUtils.appGroupUserDefault.set(nil, forKey: "LCCertificateData")
             LCUtils.appGroupUserDefault.set(nil, forKey: "LCCertificatePassword")
             LCUtils.appGroupUserDefault.set(nil, forKey: "LCCertificateUpdateDate")
-            sharedModel.certificateImported = sharedModel.certificateImported
+            certificateDataFound = false
         } else {
             UserDefaults.standard.set(false, forKey: "LCCertificateImported")
             UserDefaults.standard.set(nil, forKey: "LCCertificatePassword")

--- a/LiveContainerSwiftUI/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/LCSettingsView.swift
@@ -642,6 +642,7 @@ struct LCSettingsView: View {
             LCUtils.appGroupUserDefault.set(certificateData, forKey: "LCCertificateData")
             LCUtils.appGroupUserDefault.set(certificatePassword, forKey: "LCCertificatePassword")
             LCUtils.appGroupUserDefault.set(NSDate.now, forKey: "LCCertificateUpdateDate")
+            sharedModel.certificateImported = sharedModel.certificateImported
         } else {
             UserDefaults.standard.set(certificatePassword, forKey: "LCCertificatePassword")
             UserDefaults.standard.set(certificateData, forKey: "LCCertificateData")
@@ -679,6 +680,7 @@ struct LCSettingsView: View {
             LCUtils.appGroupUserDefault.set(nil, forKey: "LCCertificateData")
             LCUtils.appGroupUserDefault.set(nil, forKey: "LCCertificatePassword")
             LCUtils.appGroupUserDefault.set(nil, forKey: "LCCertificateUpdateDate")
+            sharedModel.certificateImported = sharedModel.certificateImported
         } else {
             UserDefaults.standard.set(false, forKey: "LCCertificateImported")
             UserDefaults.standard.set(nil, forKey: "LCCertificatePassword")

--- a/LiveContainerSwiftUI/LCUtils.h
+++ b/LiveContainerSwiftUI/LCUtils.h
@@ -5,6 +5,7 @@ typedef void (^LCParseMachOCallback)(const char *path, struct mach_header_64 *he
 typedef NS_ENUM(NSInteger, Store){
     SideStore = 0,
     AltStore = 1,
+    ADP = 2,
     Unknown = -1
 };
 

--- a/LiveContainerSwiftUI/LCUtils.m
+++ b/LiveContainerSwiftUI/LCUtils.m
@@ -265,6 +265,8 @@ Class LCSharedUtilsClass = nil;
             ans = AltStore;
         } else if ([[self appGroupID] containsString:@"SideStore"] && ![[self appGroupID] isEqualToString:@"group.com.SideStore.SideStore"]) {
             ans = SideStore;
+        } else if (![[self appGroupID] containsString:@"Unknown"] ) {
+            ans = ADP;
         } else {
             ans = Unknown;
         }

--- a/LiveContainerSwiftUI/LCUtils.m
+++ b/LiveContainerSwiftUI/LCUtils.m
@@ -279,7 +279,7 @@ Class LCSharedUtilsClass = nil;
 }
 
 + (BOOL)isAppGroupAltStoreLike {
-    return ![self.appGroupID isEqualToString:@"Unknown"];
+    return [self.appGroupID containsString:@"SideStore"] || [self.appGroupID containsString:@"AltStore"];
 }
 
 + (void)changeMainExecutableTo:(NSString *)exec error:(NSError **)error {

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -761,6 +761,8 @@ extension LCUtils {
             return "AltStore"
         case .SideStore:
             return "SideStore"
+        case .ADP:
+            return "ADP"
         default:
             return "Unknown Store"
         }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4272,6 +4272,29 @@
         }
       }
     },
+    "lc.common.ADP" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ADP Certificate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开发者证书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開發者證書"
+          }
+        }
+      }
+    },
     "lc.common.auto" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -9409,6 +9432,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "App橫幅的顏色隨著圖標變化"
+          }
+        }
+      }
+    },
+    "lc.settings.error.certNotImported" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You must import ADP certificate before testing JIT-Less mode."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在设测试JIT模式前，你必须要先导入开发者证书。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在測試免JIT模式前，你需要先匯入開發者證書。"
           }
         }
       }


### PR DESCRIPTION
Achieve multitasking by moving data to custom app group for ADP certificate.

- Detect App Group in entitlement file after trying SideStore/AltStore group id.
- Add `Store` type: **ADP**, it enabled when detected custom app group.
- Write cert data and password to group's user default in ADP method.
- Add JITLess test for ADP method.
- Allow converting app to Shared in ADP method