### PR TITLE
Update StikJIT name to StikDebug

### DIFF
--- a/LiveContainerSwiftUI/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/LCSettingsView.swift
@@ -16,7 +16,7 @@ enum PatchChoice {
 
 enum JITEnablerType : Int {
     case SideJITServer = 0
-    case StkiJIT = 1
+    case StikDebug = 1
     case JITStreamerEBLegacy = 2
     case StikJITLC = 3
     case SideStore = 4
@@ -173,7 +173,7 @@ struct LCSettingsView: View {
                     }
                     Picker(selection: $JITEnabler) {
                         Text("SideJITServer/JITStreamer 2.0").tag(JITEnablerType.SideJITServer)
-                        Text("StikJIT (StandAlone)").tag(JITEnablerType.StkiJIT)
+                        Text("StikDebug (Standalone)").tag(JITEnablerType.StikDebug)
                         Text("StikJIT (Another LiveContainer)").tag(JITEnablerType.StikJITLC)
                         Text("SideStore").tag(JITEnablerType.SideStore)
                         Text("JitStreamer-EB (Relaunch)").tag(JITEnablerType.JITStreamerEBLegacy)

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -843,7 +843,7 @@ extension LCUtils {
                 onServerMessage?("Failed to contact JitStreamer-EB server: \(error)")
             }
             
-        } else if jitEnabler == .StkiJIT || jitEnabler == .StikJITLC {
+        } else if jitEnabler == .StikDebug || jitEnabler == .StikJITLC {
             let launchURLStr = "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)"
             let launchURL : URL
             if jitEnabler == .StikJITLC {
@@ -866,7 +866,7 @@ extension LCUtils {
                 
             } else {
                 launchURL = URL(string: launchURLStr)!
-                onServerMessage?("JIT acquisition will continue in StikJIT.")
+                onServerMessage?("JIT acquisition will continue in StikDebug.")
             }
             await UIApplication.shared.open(launchURL)
         } else if jitEnabler == .SideStore {


### PR DESCRIPTION
Updates StikJIT name to StikDebug following the App Store release, url scheme stays the same though