### PR TITLE
Add app list sort option

### DIFF
--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -74,26 +74,41 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     
     @State private var helpPresent = false
     
+    @State private var customSortViewPresent = false
+    @State private var selectedSortType: AppSortType = .alphabetical
+    
     @EnvironmentObject private var sharedModel : SharedModel
     @AppStorage("LCMultitaskMode", store: LCUtils.appGroupUserDefault) var multitaskMode: MultitaskMode = .virtualWindow
     @AppStorage("LCLaunchInMultitaskMode") var launchInMultitaskMode = false
     
     @ObservedObject var searchContext = SearchContext()
+    
+    var sortedApps: [LCAppModel] {
+        return sharedModel.apps
+    }
+    
+    var sortedHiddenApps: [LCAppModel] {
+        return sharedModel.hiddenApps
+    }
+    
     var filteredApps: [LCAppModel] {
+        let apps = sortedApps
         if searchContext.debouncedQuery.isEmpty {
-            sharedModel.apps
+            return apps
         } else {
-            sharedModel.apps.filter { app in
+            return apps.filter { app in
                 app.appInfo.displayName().localizedCaseInsensitiveContains(searchContext.debouncedQuery) ||
                 app.appInfo.bundleIdentifier()!.localizedCaseInsensitiveContains(searchContext.debouncedQuery)
             }
         }
     }
+    
     var filteredHiddenApps: [LCAppModel] {
+        let apps = sortedHiddenApps
         if searchContext.debouncedQuery.isEmpty || !sharedModel.isHiddenAppUnlocked {
-            sharedModel.hiddenApps
+            return apps
         } else {
-            sharedModel.hiddenApps.filter { app in
+            return apps.filter { app in
                 app.appInfo.displayName().localizedCaseInsensitiveContains(searchContext.debouncedQuery) ||
                 app.appInfo.bundleIdentifier()!.localizedCaseInsensitiveContains(searchContext.debouncedQuery)
             }
@@ -121,11 +136,14 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                     ForEach(filteredApps, id: \.self) { app in
                         LCAppBanner(appModel: app, delegate: self, appDataFolders: $appDataFolderNames, tweakFolders: $tweakFolderNames)
                     }
+                    .onMove(perform: sharedModel.appSortType == .custom && searchContext.debouncedQuery.isEmpty ? { source, destination in
+                        sharedModel.moveAppInCustomSort(from: source, to: destination, isHidden: false)
+                    } : nil)
                     .transition(.scale)
-                    
                 }
                 .padding()
                 .animation(searchContext.isTyping ? nil : .easeInOut, value: filteredApps)
+                .animation(.easeInOut, value: sharedModel.appSortType)
 
                 VStack {
                     if LCUtils.appGroupUserDefault.bool(forKey: "LCStrictHiding") {
@@ -136,13 +154,26 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                                         .font(.system(.title2).bold())
                                     Spacer()
                                 }
-                                ForEach(filteredHiddenApps, id: \.self) { app in
-                                    LCAppBanner(appModel: app, delegate: self, appDataFolders: $appDataFolderNames, tweakFolders: $tweakFolderNames)
+                                
+                                if sharedModel.appSortType == .custom && searchContext.debouncedQuery.isEmpty {
+                                    ForEach(filteredHiddenApps, id: \.self) { app in
+                                        LCAppBanner(appModel: app, delegate: self, appDataFolders: $appDataFolderNames, tweakFolders: $tweakFolderNames)
+                                    }
+                                    .onMove { source, destination in
+                                        sharedModel.moveAppInCustomSort(from: source, to: destination, isHidden: true)
+                                    }
+                                    .transition(.scale)
+                                } else {
+                                    ForEach(filteredHiddenApps, id: \.self) { app in
+                                        LCAppBanner(appModel: app, delegate: self, appDataFolders: $appDataFolderNames, tweakFolders: $tweakFolderNames)
+                                    }
+                                    .transition(.scale)
                                 }
                             }
                             .padding()
                             .transition(.opacity)
-                            .animation(searchContext.isTyping ? nil : .easeInOut, value: filteredApps)
+                            .animation(searchContext.isTyping ? nil : .easeInOut, value: filteredHiddenApps)
+                            .animation(.easeInOut, value: sharedModel.appSortType)
                             
                             if sharedModel.hiddenApps.count == 0 {
                                 Text("lc.appList.hideAppTip".loc)
@@ -169,7 +200,8 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             }
                         }
                         .padding()
-                        .animation(searchContext.isTyping ? nil : .easeInOut, value: filteredApps)
+                        .animation(searchContext.isTyping ? nil : .easeInOut, value: filteredHiddenApps)
+                        .animation(.easeInOut, value: sharedModel.appSortType)
                     }
 
                     let appCount = sharedModel.isHiddenAppUnlocked ? filteredApps.count + filteredHiddenApps.count : filteredApps.count
@@ -193,6 +225,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 if !didAppear {
                     onAppear()
                 }
+                selectedSortType = sharedModel.appSortType
             }
             
             .navigationTitle("lc.appList.myApps".loc)
@@ -228,9 +261,38 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                         Task { await onOpenWebViewTapped() }
                     })
                 }
+                
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Picker("Sort by", selection: $sharedModel.appSortType) {
+                            ForEach(AppSortType.allCases, id: \.self) { sortType in
+                                Label(sortType.displayName, systemImage: sortType.systemImage)
+                                    .tag(sortType)
+                            }
+                        }
+                        .onChange(of: sharedModel.appSortType) { newValue in
+                            if newValue == .custom {
+                                if sharedModel.customSortOrder.isEmpty {
+                                    let currentOrder = (sharedModel.apps + sharedModel.hiddenApps)
+                                        .compactMap { $0.appInfo.bundleIdentifier() }
+                                    sharedModel.updateCustomSortOrder(currentOrder)
+                                }
+                            }
+                            sharedModel.updateSortType(newValue)
+                        }
+                        
+                        Divider()
+                        
+                        Button {
+                            customSortViewPresent = true
+                        } label: {
+                            Label("lc.appList.sort.customManage".loc, systemImage: "slider.horizontal.3")
+                        }
+                    } label: {
+                        Label("lc.appList.sort".loc, systemImage: "ellipsis.circle")
+                    }
+                }
             }
-
-            
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .alert("lc.common.error".loc, isPresented: $errorShow){
@@ -318,6 +380,9 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         .sheet(isPresented: $helpPresent) {
             LCHelpView(isPresent: $helpPresent)
         }
+        .sheet(isPresented: $customSortViewPresent) {
+            LCCustomSortView()
+        }
         .onOpenURL { url in
             handleURL(url: url)
         }
@@ -380,7 +445,6 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         await openWebView(urlString: urlToOpen)
         
     }
-    
     func onAppear() {
         for app in sharedModel.apps {
             app.delegate = self
@@ -638,18 +702,16 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                         return appNow == appToReplace
                     }
                     sharedModel.hiddenApps.append(LCAppModel(appInfo: finalNewApp, delegate: self))
-                    sharedModel.hiddenApps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
                 } else {
                     sharedModel.apps.removeAll { appNow in
                         return appNow == appToReplace
                     }
                     sharedModel.apps.append(LCAppModel(appInfo: finalNewApp, delegate: self))
-                    sharedModel.apps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
                 }
-
+                sharedModel.sortApps()
             } else {
-                sharedModel.apps.append(LCAppModel(appInfo: finalNewApp, delegate: self))
-                sharedModel.apps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
+                let newAppModel = LCAppModel(appInfo: finalNewApp, delegate: self)
+                sharedModel.addNewApp(newAppModel)
             }
 
             self.installprogressVisible = false
@@ -769,14 +831,13 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                     return app == now
                 }
                 sharedModel.hiddenApps.append(app)
-                sharedModel.hiddenApps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
             } else {
                 sharedModel.hiddenApps.removeAll { now in
                     return app == now
                 }
                 sharedModel.apps.append(app)
-                sharedModel.apps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
             }
+            sharedModel.sortApps()
         }
     }
     

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -821,6 +821,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             sharedModel.hiddenApps.removeAll { now in
                 return app == now
             }
+            sharedModel.cleanupCustomSortOrder()
         }
     }
     

--- a/LiveContainerSwiftUI/LCAppSortManager.swift
+++ b/LiveContainerSwiftUI/LCAppSortManager.swift
@@ -1,0 +1,144 @@
+//
+//  LCAppSortManager.swift
+//  LiveContainer
+//
+//  Created by boa-z on 2025/6/22.
+//
+
+import Foundation
+import SwiftUI
+
+/// App sorting business logic manager
+class LCAppSortManager {
+    
+    // MARK: - Unique Identifier Methods
+    
+    /// Generate unique identifier for app using bundleId:relativePath format
+    static func getUniqueIdentifier(for app: LCAppModel) -> String? {
+        guard let bundleId = app.appInfo.bundleIdentifier(),
+              let relativePath = app.appInfo.relativeBundlePath else {
+            return nil
+        }
+        return "\(bundleId):\(relativePath)"
+    }
+    
+    /// Check if unique identifier matches the app
+    static func matches(uniqueId: String, app: LCAppModel) -> Bool {
+        guard let appUniqueId = getUniqueIdentifier(for: app) else {
+            return false
+        }
+        return uniqueId == appUniqueId
+    }
+    
+    // MARK: - Sorting Methods
+    
+    /// Sort app list by specified sort type
+    static func getSortedApps(_ appList: [LCAppModel], sortType: AppSortType, customSortOrder: [String]) -> [LCAppModel] {
+        switch sortType {
+        case .alphabetical:
+            return appList.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        case .reverseAlphabetical:
+            return appList.sorted { $0.appInfo.displayName() > $1.appInfo.displayName() }
+        case .custom:
+            return sortByCustomOrder(appList, customSortOrder: customSortOrder)
+        }
+    }
+    
+    /// Sort app list by custom order using unique identifiers
+    private static func sortByCustomOrder(_ appList: [LCAppModel], customSortOrder: [String]) -> [LCAppModel] {
+        if customSortOrder.isEmpty {
+            return appList.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        }
+        
+        var sortedApps: [LCAppModel] = []
+        var remainingApps = appList
+        
+        for uniqueId in customSortOrder {
+            if let index = remainingApps.firstIndex(where: { matches(uniqueId: uniqueId, app: $0) }) {
+                sortedApps.append(remainingApps.remove(at: index))
+            }
+        }
+        
+        remainingApps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        sortedApps.append(contentsOf: remainingApps)
+        
+        return sortedApps
+    }
+    
+    // MARK: - Drag & Drop Methods
+    
+    /// Generate new sort order after drag and drop operation
+    static func generateMoveOrder(for targetApps: [LCAppModel], 
+                                  currentCustomOrder: [String], 
+                                  from source: IndexSet, 
+                                  to destination: Int) -> [String] {
+        let uniqueIds = targetApps.compactMap { getUniqueIdentifier(for: $0) }
+        
+        var newOrder = currentCustomOrder.isEmpty ? uniqueIds : currentCustomOrder
+        
+        for uniqueId in uniqueIds {
+            if !newOrder.contains(uniqueId) {
+                newOrder.append(uniqueId)
+            }
+        }
+        
+        newOrder.move(fromOffsets: source, toOffset: destination)
+        return newOrder
+    }
+    
+    // MARK: - Cleanup Methods
+    
+    /// Remove invalid entries from custom sort order
+    static func cleanupCustomSortOrder(_ currentCustomOrder: [String], 
+                                       apps: [LCAppModel], 
+                                       hiddenApps: [LCAppModel]) -> [String] {
+        let allApps = apps + hiddenApps
+        let validUniqueIds = Set(allApps.compactMap { getUniqueIdentifier(for: $0) })
+        
+        let cleanedOrder = currentCustomOrder.filter { validUniqueIds.contains($0) }
+        return cleanedOrder
+    }
+    
+    // MARK: - App Management Methods
+    
+    /// Prepare insertion info for new app without modifying arrays
+    static func prepareAddOrder(for app: LCAppModel,
+                                sortType: AppSortType,
+                                apps: [LCAppModel],
+                                hiddenApps: [LCAppModel],
+                                currentCustomOrder: [String]) -> (insertToHidden: Bool, insertIndex: Int, newCustomOrder: [String]) {
+        guard let uniqueId = getUniqueIdentifier(for: app) else {
+            return (app.appInfo.isHidden, app.appInfo.isHidden ? hiddenApps.count : apps.count, currentCustomOrder)
+        }
+        
+        let targetArray = app.appInfo.isHidden ? hiddenApps : apps
+        let insertToHidden = app.appInfo.isHidden
+        
+        switch sortType {
+        case .alphabetical:
+            let insertIndex = targetArray.firstIndex { $0.appInfo.displayName() > app.appInfo.displayName() } ?? targetArray.count
+            return (insertToHidden, insertIndex, currentCustomOrder)
+            
+        case .reverseAlphabetical:
+            let insertIndex = targetArray.firstIndex { $0.appInfo.displayName() < app.appInfo.displayName() } ?? targetArray.count
+            return (insertToHidden, insertIndex, currentCustomOrder)
+            
+        case .custom:
+            var newOrder = currentCustomOrder
+            if !newOrder.contains(uniqueId) {
+                newOrder.append(uniqueId)
+            }
+            return (insertToHidden, targetArray.count, newOrder)
+        }
+    }
+    
+    // MARK: - Utility Methods
+    
+    /// Return updated custom order if cleanup is needed, otherwise nil
+    static func getUpdatedCustomOrderIfNeeded(_ currentCustomOrder: [String], 
+                                              apps: [LCAppModel], 
+                                              hiddenApps: [LCAppModel]) -> [String]? {
+        let cleanedOrder = cleanupCustomSortOrder(currentCustomOrder, apps: apps, hiddenApps: hiddenApps)
+        return cleanedOrder.count != currentCustomOrder.count ? cleanedOrder : nil
+    }
+}

--- a/LiveContainerSwiftUI/LCCustomSortView.swift
+++ b/LiveContainerSwiftUI/LCCustomSortView.swift
@@ -133,39 +133,21 @@ struct LCCustomSortView: View {
     }
     
     private func getSortedByCustomOrder(_ appList: [LCAppModel]) -> [LCAppModel] {
-        if sharedModel.customSortOrder.isEmpty {
-            return appList.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
-        }
-        
-        var sortedApps: [LCAppModel] = []
-        var remainingApps = appList
-        
-        for bundleId in sharedModel.customSortOrder {
-            if let index = remainingApps.firstIndex(where: { $0.appInfo.bundleIdentifier() == bundleId }) {
-                sortedApps.append(remainingApps.remove(at: index))
-            }
-        }
-        
-        remainingApps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
-        sortedApps.append(contentsOf: remainingApps)
-        
-        return sortedApps
+        return LCAppSortManager.getSortedApps(appList, sortType: .custom, customSortOrder: sharedModel.customSortOrder)
     }
     
     private func updateCustomSortOrder() {
         var newOrder: [String] = []
         
-        // 添加普通应用的顺序
         for app in apps {
-            if let bundleId = app.appInfo.bundleIdentifier() {
-                newOrder.append(bundleId)
+            if let uniqueId = LCAppSortManager.getUniqueIdentifier(for: app) {
+                newOrder.append(uniqueId)
             }
         }
         
-        // 添加隐藏应用的顺序
         for app in hiddenApps {
-            if let bundleId = app.appInfo.bundleIdentifier() {
-                newOrder.append(bundleId)
+            if let uniqueId = LCAppSortManager.getUniqueIdentifier(for: app) {
+                newOrder.append(uniqueId)
             }
         }
         

--- a/LiveContainerSwiftUI/LCCustomSortView.swift
+++ b/LiveContainerSwiftUI/LCCustomSortView.swift
@@ -1,0 +1,185 @@
+//
+//  LCCustomSortView.swift
+//  LiveContainerSwiftUI
+//
+//  Created by boa-z on 2025/6/21.
+//
+
+import SwiftUI
+
+struct LCCustomSortView: View {
+    @EnvironmentObject private var sharedModel: SharedModel
+    @Environment(\.presentationMode) var presentationMode
+    
+    @State private var apps: [LCAppModel] = []
+    @State private var hiddenApps: [LCAppModel] = []
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                if !apps.isEmpty {
+                    // Section("lc.appList.visibleApps".loc) {
+                        ForEach(apps, id: \.self) { app in
+                            HStack {
+                                Image(uiImage: app.appInfo.icon())
+                                    .resizable()
+                                    .frame(width: 60, height: 60)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(app.appInfo.displayName())
+                                        .font(.system(size: 16, weight: .bold))
+                                        .lineLimit(1)
+                                    Text("\(app.appInfo.version() ?? "?") - \(app.appInfo.bundleIdentifier() ?? "?")")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                    Text(app.uiSelectedContainer?.name ?? "lc.appBanner.noDataFolder".loc)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+                                
+                                Spacer()
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .onMove { source, destination in
+                            apps.move(fromOffsets: source, toOffset: destination)
+                            updateCustomSortOrder()
+                        }
+                    // }
+                }
+                
+                if sharedModel.isHiddenAppUnlocked && !hiddenApps.isEmpty {
+                    Section("lc.appList.hiddenApps".loc) {
+                        ForEach(hiddenApps, id: \.self) { app in
+                            HStack {
+                                Image(uiImage: app.appInfo.icon())
+                                    .resizable()
+                                    .frame(width: 60, height: 60)
+                                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                                
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(app.appInfo.displayName())
+                                        .font(.system(size: 16, weight: .bold))
+                                        .lineLimit(1)
+                                    Text("\(app.appInfo.version() ?? "?") - \(app.appInfo.bundleIdentifier() ?? "?")")
+                                        .font(.system(size: 12))
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                    Text(app.uiSelectedContainer?.name ?? "lc.appBanner.noDataFolder".loc)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+                                
+                                Spacer()
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .onMove { source, destination in
+                            hiddenApps.move(fromOffsets: source, toOffset: destination)
+                            updateCustomSortOrder()
+                        }
+                    }
+                }
+                
+                Section {
+                    Button("lc.appList.sort.resetToAlphabetical".loc) {
+                        resetToAlphabetical()
+                    }
+                    .foregroundColor(.orange)
+                } footer: {
+                    Text("lc.appList.sort.customSortTip".loc)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .navigationTitle("lc.appList.sort.custom".loc)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("lc.common.cancel".loc) {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+                
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if #available(iOS 16.0, *) {
+                        Button("lc.common.done".loc) {
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                        .font(.system(size: 17))
+                        .fontWeight(.bold)
+                    } else {
+                        Button("lc.common.done".loc) {
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                        .font(.system(size: 17, weight: .bold))
+                    }
+                }
+            }
+            .environment(\.editMode, .constant(.active))
+        }
+        .onAppear {
+            loadApps()
+        }
+    }
+    
+    private func loadApps() {
+        apps = getSortedByCustomOrder(sharedModel.apps)
+        hiddenApps = getSortedByCustomOrder(sharedModel.hiddenApps)
+    }
+    
+    private func getSortedByCustomOrder(_ appList: [LCAppModel]) -> [LCAppModel] {
+        if sharedModel.customSortOrder.isEmpty {
+            return appList.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        }
+        
+        var sortedApps: [LCAppModel] = []
+        var remainingApps = appList
+        
+        for bundleId in sharedModel.customSortOrder {
+            if let index = remainingApps.firstIndex(where: { $0.appInfo.bundleIdentifier() == bundleId }) {
+                sortedApps.append(remainingApps.remove(at: index))
+            }
+        }
+        
+        remainingApps.sort { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        sortedApps.append(contentsOf: remainingApps)
+        
+        return sortedApps
+    }
+    
+    private func updateCustomSortOrder() {
+        var newOrder: [String] = []
+        
+        // 添加普通应用的顺序
+        for app in apps {
+            if let bundleId = app.appInfo.bundleIdentifier() {
+                newOrder.append(bundleId)
+            }
+        }
+        
+        // 添加隐藏应用的顺序
+        for app in hiddenApps {
+            if let bundleId = app.appInfo.bundleIdentifier() {
+                newOrder.append(bundleId)
+            }
+        }
+        
+        sharedModel.updateCustomSortOrder(newOrder)
+    }
+    
+    private func resetToAlphabetical() {
+        apps = sharedModel.apps.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        hiddenApps = sharedModel.hiddenApps.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        updateCustomSortOrder()
+    }
+}
+
+#Preview {
+    LCCustomSortView()
+        .environmentObject(DataManager.shared.model)
+}

--- a/LiveContainerSwiftUI/LiveContainerSwiftUIApp.swift
+++ b/LiveContainerSwiftUI/LiveContainerSwiftUIApp.swift
@@ -80,10 +80,9 @@ struct LiveContainerSwiftUIApp : App {
             NSLog("[LC] error:\(error)")
         }
         
-        // 设置应用数据并进行初始排序
-        DataManager.shared.model.apps = tempApps
-        DataManager.shared.model.hiddenApps = tempHiddenApps
-        DataManager.shared.model.sortApps()
+
+        let allScannedApps = tempApps + tempHiddenApps
+        DataManager.shared.model.appSortManager.setInitialApps(allScannedApps)
         
         _appDataFolderNames = State(initialValue: tempAppDataFolderNames)
         _tweakFolderNames = State(initialValue: tempTweakFolderNames)

--- a/LiveContainerSwiftUI/LiveContainerSwiftUIApp.swift
+++ b/LiveContainerSwiftUI/LiveContainerSwiftUIApp.swift
@@ -79,8 +79,12 @@ struct LiveContainerSwiftUIApp : App {
         } catch {
             NSLog("[LC] error:\(error)")
         }
-        DataManager.shared.model.apps = tempApps.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
-        DataManager.shared.model.hiddenApps = tempHiddenApps.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
+        
+        // 设置应用数据并进行初始排序
+        DataManager.shared.model.apps = tempApps
+        DataManager.shared.model.hiddenApps = tempHiddenApps
+        DataManager.shared.model.sortApps()
+        
         _appDataFolderNames = State(initialValue: tempAppDataFolderNames)
         _tweakFolderNames = State(initialValue: tempTweakFolderNames)
     }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3403,6 +3403,72 @@
         }
       }
     },
+    "lc.appList.sort.customManage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom Manage"
+          }
+        }
+      }
+    },
+    "lc.appList.sort.resetToAlphabetical" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset to Alphabetical"
+          }
+        }
+      }
+    },
+    "lc.appList.sort.customSortTip" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will reset the custom sort order to alphabetical order."
+          }
+        }
+      }
+    },
+    "lc.appList.sort.alphabetical" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name (A–Z)"
+          }
+        }
+      }
+    },
+    "lc.appList.sort.reverseAlphabetical" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name (Z–A)"
+          }
+        }
+      }
+    },
+    "lc.appList.sort.custom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Custom"
+          }
+        }
+      }
+    },
     "lc.apppSettings.orientationLock" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
Implements app list sorting functionality to address issue #600, providing users with flexible options to organize their app collection.

- **Multiple Sort Options**: Supports alphabetical (A-Z), reverse alphabetical (Z-A), and custom sorting
- **Custom Sort Management**: New `LCCustomSortView` interface with drag-and-drop reordering capability
