### PR TITLE
feat: Sort by Launchdate

### DIFF
--- a/LiveContainerSwiftUI/LCAppInfo.h
+++ b/LiveContainerSwiftUI/LCAppInfo.h
@@ -33,6 +33,7 @@ typedef NS_ENUM(NSInteger, LCOrientationLock){
 @property bool autoSaveDisabled;
 @property bool dontSign;
 @property bool spoofSDKVersion;
+@property NSDate* lastLaunched;
 
 @property bool is32bit;
 

--- a/LiveContainerSwiftUI/LCAppInfo.m
+++ b/LiveContainerSwiftUI/LCAppInfo.m
@@ -624,4 +624,13 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     [self save];
 }
 
+- (NSDate*)lastLaunched {
+    return _info[@"lastLaunched"];
+}
+
+- (void)setLastLaunched:(NSDate*)lastLaunched {
+    _info[@"lastLaunched"] = lastLaunched;
+    [self save];
+}
+
 @end

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -83,13 +83,12 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     @AppStorage("LCLaunchInMultitaskMode") var launchInMultitaskMode = false
     
     @ObservedObject var searchContext = SearchContext()
-    
     var sortedApps: [LCAppModel] {
-        return sharedModel.apps
+        return sharedAppSortManager.getSortedApps(sharedModel.apps, sortType: sharedAppSortManager.appSortType, customSortOrder: sharedAppSortManager.customSortOrder)
     }
     
     var sortedHiddenApps: [LCAppModel] {
-        return sharedModel.hiddenApps
+        return sharedAppSortManager.getSortedApps(sharedModel.hiddenApps, sortType: sharedAppSortManager.appSortType, customSortOrder: sharedAppSortManager.customSortOrder)
     }
     
     var filteredApps: [LCAppModel] {
@@ -258,24 +257,30 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
-
-                        Picker("Sort by", selection: $sharedAppSortManager.appSortType) {
-                            ForEach(AppSortType.allCases, id: \.self) { sortType in
-                                Label(sortType.displayName, systemImage: sortType.systemImage)
-                                    .tag(sortType)
-                            }
-                        }
-
-                        Divider()
-                        
-                        Button {
-                            customSortViewPresent = true
-                        } label: {
-                            Label("lc.appList.sort.customManage".loc, systemImage: "slider.horizontal.3")
-                        }
-                    } label: {
-                        Label("lc.appList.sort".loc, systemImage: "ellipsis.circle")
+                    // Add the last launched toggle
+                    Toggle(isOn: $sharedAppSortManager.sortByLastLaunched) {
+                        Label("Sort by Last Opened", systemImage: "clock")
                     }
+                    
+                    Divider()
+
+                    Picker("Sort by", selection: $sharedAppSortManager.appSortType) {
+                        ForEach(AppSortType.allCases, id: \.self) { sortType in
+                            Label(sortType.displayName, systemImage: sortType.systemImage)
+                                .tag(sortType)
+                        }
+                    }
+
+                    Divider()
+                    
+                    Button {
+                        customSortViewPresent = true
+                    } label: {
+                        Label("lc.appList.sort.customManage".loc, systemImage: "slider.horizontal.3")
+                    }
+                } label: {
+                    Label("lc.appList.sort".loc, systemImage: "ellipsis.circle")
+                }
                 }
             }
         }

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -77,18 +77,17 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     @State private var customSortViewPresent = false
     
     @EnvironmentObject private var sharedModel : SharedModel
-    @EnvironmentObject private var sharedAppSortManager : LCAppSortManager
     
     @AppStorage("LCMultitaskMode", store: LCUtils.appGroupUserDefault) var multitaskMode: MultitaskMode = .virtualWindow
     @AppStorage("LCLaunchInMultitaskMode") var launchInMultitaskMode = false
     
     @ObservedObject var searchContext = SearchContext()
     var sortedApps: [LCAppModel] {
-        return sharedAppSortManager.getSortedApps(sharedModel.apps, sortType: sharedAppSortManager.appSortType, customSortOrder: sharedAppSortManager.customSortOrder)
+        return sharedModel.apps
     }
     
     var sortedHiddenApps: [LCAppModel] {
-        return sharedAppSortManager.getSortedApps(sharedModel.hiddenApps, sortType: sharedAppSortManager.appSortType, customSortOrder: sharedAppSortManager.customSortOrder)
+        return sharedModel.hiddenApps
     }
     
     var filteredApps: [LCAppModel] {
@@ -257,30 +256,23 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
-                    // Add the last launched toggle
-                    Toggle(isOn: $sharedAppSortManager.sortByLastLaunched) {
-                        Label("Sort by Last Opened", systemImage: "clock")
-                    }
-                    
-                    Divider()
-
-                    Picker("Sort by", selection: $sharedAppSortManager.appSortType) {
-                        ForEach(AppSortType.allCases, id: \.self) { sortType in
-                            Label(sortType.displayName, systemImage: sortType.systemImage)
-                                .tag(sortType)
+                        Picker("Sort by", selection: $sharedAppSortManager.appSortType) {
+                            ForEach(AppSortType.allCases, id: \.self) { sortType in
+                                Label(sortType.displayName, systemImage: sortType.systemImage)
+                                    .tag(sortType)
+                            }
                         }
-                    }
 
-                    Divider()
-                    
-                    Button {
-                        customSortViewPresent = true
+                        Divider()
+                        
+                        Button {
+                            customSortViewPresent = true
+                        } label: {
+                            Label("lc.appList.sort.customManage".loc, systemImage: "slider.horizontal.3")
+                        }
                     } label: {
-                        Label("lc.appList.sort.customManage".loc, systemImage: "slider.horizontal.3")
+                        Label("lc.appList.sort".loc, systemImage: "ellipsis.circle")
                     }
-                } label: {
-                    Label("lc.appList.sort".loc, systemImage: "ellipsis.circle")
-                }
                 }
             }
         }

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -77,6 +77,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     @State private var customSortViewPresent = false
     
     @EnvironmentObject private var sharedModel : SharedModel
+    @EnvironmentObject private var sharedAppSortManager : LCAppSortManager
     
     @AppStorage("LCMultitaskMode", store: LCUtils.appGroupUserDefault) var multitaskMode: MultitaskMode = .virtualWindow
     @AppStorage("LCLaunchInMultitaskMode") var launchInMultitaskMode = false

--- a/LiveContainerSwiftUI/LCAppModel.swift
+++ b/LiveContainerSwiftUI/LCAppModel.swift
@@ -258,6 +258,9 @@ class LCAppModel: ObservableObject, Hashable {
             LCUtils.launchToGuestApp()
         }
         
+        // Record the launch time
+        appInfo.lastLaunched = Date()
+
         await MainActor.run {
             isAppRunning = false
         }

--- a/LiveContainerSwiftUI/LCAppSortManager.swift
+++ b/LiveContainerSwiftUI/LCAppSortManager.swift
@@ -80,24 +80,22 @@ class LCAppSortManager: ObservableObject {
     }
     
     func getSortedApps(_ appList: [LCAppModel], sortType: AppSortType, customSortOrder: [String]) -> [LCAppModel] {
-        var apps = appList
-        
         switch sortType {
         case .alphabetical:
-            return apps.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
+            return appList.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
             
         case .reverseAlphabetical:
-            return apps.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedDescending }
+            return appList.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedDescending }
             
         case .lastLaunched:
-            let appsWithLaunchDate = apps.compactMap { app -> (LCAppModel, Date)? in
+            let appsWithLaunchDate = appList.compactMap { app -> (LCAppModel, Date)? in
                 guard let launchDate = app.appInfo.lastLaunched else { return nil }
                 return (app, launchDate)
             }
             .sorted { $0.1 > $1.1 } // Sort by date, newest first
             .map { $0.0 } // Extract just the app models
 
-            let appsWithoutLaunchDate = apps.filter { app in
+            let appsWithoutLaunchDate = appList.filter { app in
                 return app.appInfo.lastLaunched == nil
             }
             .sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
@@ -105,7 +103,7 @@ class LCAppSortManager: ObservableObject {
             return appsWithLaunchDate + appsWithoutLaunchDate
             
         case .custom:
-            return sortByCustomOrder(apps, customSortOrder: customSortOrder)
+            return sortByCustomOrder(appList, customSortOrder: customSortOrder)
         }
     }
     

--- a/LiveContainerSwiftUI/LCAppSortManager.swift
+++ b/LiveContainerSwiftUI/LCAppSortManager.swift
@@ -82,10 +82,10 @@ class LCAppSortManager: ObservableObject {
     func getSortedApps(_ appList: [LCAppModel], sortType: AppSortType, customSortOrder: [String]) -> [LCAppModel] {
         switch sortType {
         case .alphabetical:
-            return appList.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
+            return appList.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
             
         case .reverseAlphabetical:
-            return appList.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedDescending }
+            return appList.sorted { $0.appInfo.displayName() > $1.appInfo.displayName() }
             
         case .lastLaunched:
             let appsWithLaunchDate = appList.compactMap { app -> (LCAppModel, Date)? in
@@ -98,7 +98,7 @@ class LCAppSortManager: ObservableObject {
             let appsWithoutLaunchDate = appList.filter { app in
                 return app.appInfo.lastLaunched == nil
             }
-            .sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
+            .sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
             
             return appsWithLaunchDate + appsWithoutLaunchDate
             

--- a/LiveContainerSwiftUI/LCAppSortManager.swift
+++ b/LiveContainerSwiftUI/LCAppSortManager.swift
@@ -19,12 +19,6 @@ class LCAppSortManager: ObservableObject {
             applySort()
         }
     }
-    
-    @AppStorage("LCSortByLastLaunched", store: LCUtils.appGroupUserDefault) var sortByLastLaunched: Bool = true {
-        didSet {
-            applySort()
-        }
-    }
 
     @Published var customSortOrder: [String] {
         didSet {
@@ -88,8 +82,14 @@ class LCAppSortManager: ObservableObject {
     func getSortedApps(_ appList: [LCAppModel], sortType: AppSortType, customSortOrder: [String]) -> [LCAppModel] {
         var apps = appList
         
-        // Apply last launched sorting first if enabled
-        if sortByLastLaunched {
+        switch sortType {
+        case .alphabetical:
+            return apps.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
+            
+        case .reverseAlphabetical:
+            return apps.sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedDescending }
+            
+        case .lastLaunched:
             let appsWithLaunchDate = apps.compactMap { app -> (LCAppModel, Date)? in
                 guard let launchDate = app.appInfo.lastLaunched else { return nil }
                 return (app, launchDate)
@@ -100,50 +100,12 @@ class LCAppSortManager: ObservableObject {
             let appsWithoutLaunchDate = apps.filter { app in
                 return app.appInfo.lastLaunched == nil
             }
-            
-            apps = appsWithLaunchDate + appsWithoutLaunchDate
-        }
-        
-        // If we only want last launched sorting, return here
-        if sortByLastLaunched && sortType == .alphabetical {
-            // For apps without launch date, sort alphabetically
-            let appsWithLaunchDate = apps.filter { $0.appInfo.lastLaunched != nil }
-            let appsWithoutLaunchDate = apps.filter { $0.appInfo.lastLaunched == nil }
-                .sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
+            .sorted { $0.appInfo.displayName().localizedCaseInsensitiveCompare($1.appInfo.displayName()) == .orderedAscending }
             
             return appsWithLaunchDate + appsWithoutLaunchDate
-        }
-        
-        // Apply secondary sorting for apps without launch dates or when custom/reverse sorting is selected
-        switch sortType {
-        case .alphabetical:
-            if !sortByLastLaunched {
-                return apps.sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
-            } else {
-                // Keep the last launched order but sort the non-launched apps alphabetically
-                let appsWithLaunchDate = apps.filter { $0.appInfo.lastLaunched != nil }
-                let appsWithoutLaunchDate = apps.filter { $0.appInfo.lastLaunched == nil }
-                    .sorted { $0.appInfo.displayName() < $1.appInfo.displayName() }
-                return appsWithLaunchDate + appsWithoutLaunchDate
-            }
-        case .reverseAlphabetical:
-            if !sortByLastLaunched {
-                return apps.sorted { $0.appInfo.displayName() > $1.appInfo.displayName() }
-            } else {
-                // Keep the last launched order but sort the non-launched apps reverse alphabetically
-                let appsWithLaunchDate = apps.filter { $0.appInfo.lastLaunched != nil }
-                let appsWithoutLaunchDate = apps.filter { $0.appInfo.lastLaunched == nil }
-                    .sorted { $0.appInfo.displayName() > $1.appInfo.displayName() }
-                return appsWithLaunchDate + appsWithoutLaunchDate
-            }
+            
         case .custom:
-            if !sortByLastLaunched {
-                return sortByCustomOrder(apps, customSortOrder: customSortOrder)
-            } else {
-                // For custom sort with last launched, we need to respect both orders
-                // This is more complex - you might want to decide how to handle this case
-                return sortByCustomOrder(apps, customSortOrder: customSortOrder)
-            }
+            return sortByCustomOrder(apps, customSortOrder: customSortOrder)
         }
     }
     

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -15,6 +15,7 @@ import Combine
 enum AppSortType: String, CaseIterable {
     case alphabetical = "alphabetical"
     case reverseAlphabetical = "reverse_alphabetical"
+    case lastLaunched = "last_launched"
     case custom = "custom"
     
     var displayName: String {
@@ -23,6 +24,8 @@ enum AppSortType: String, CaseIterable {
             return "lc.appList.sort.alphabetical".loc
         case .reverseAlphabetical:
             return "lc.appList.sort.reverseAlphabetical".loc
+        case .lastLaunched:
+            return "lc.appList.sort.lastLaunched".loc
         case .custom:
             return "lc.appList.sort.custom".loc
         }
@@ -34,6 +37,8 @@ enum AppSortType: String, CaseIterable {
             return "chevron.down"
         case .reverseAlphabetical:
             return "chevron.up"
+        case .lastLaunched:
+            return "clock"
         case .custom:
             return "list.bullet"
         }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3781,6 +3781,17 @@
         }
       }
     },
+    "lc.appList.sort.lastLaunched" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last Opened"
+          }
+        }
+      }
+    },
     "lc.apppSettings.orientationLock" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
Extends the LCAppSortManager with the possibility to sort by the last Launchdate. With this the most recently opened apps appear first. Useful if there are some apps you use more frequently than others.
![IMG_0760](https://github.com/user-attachments/assets/6ed643c6-b85a-4b7a-9812-be7baae96327)
