### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with: 
           body: |
-            body: |
             **Commit:** [${{ github.sha }}](https://github.com/${{ github.repository }}/commit/${{ github.sha }})
             **Message:** ${{ github.event.head_commit.message }}
+            
             This is a nightly release [created automatically with GitHub Actions workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}).
           files: |
             ${{ needs.build.outputs.artifact }}

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -916,7 +916,7 @@ extension LCUtils {
                 
             } else {
                 launchURL = URL(string: launchURLStr)!
-                onServerMessage?("JIT acquisition will continue in StikJIT.")
+                onServerMessage?("JIT acquisition will continue in StikDebug.")
             }
             await UIApplication.shared.open(launchURL)
         } else if jitEnabler == .SideStore {

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ These steps can be bypassed if you don't mind enabling JIT for your app every ti
 JIT-Less mode does not mean you can't enable JIT for your apps. Instead, it means JIT is not required to launch an app. If you want to use JIT, see the instructions below in "JIT Support" section. 
 If something goes wrong, please check "JIT-Less Mode Diagnose" for more information.
 
-#### Method 1 (Requires AltStore 2.2.1+ / SideStore 0.6.2-nightly+ \[recommended])
+#### Method 1 (Requires AltStore 2.2.1+ / SideStore 0.6.2+ \[recommended])
 - Open Settings in LiveContainer 
 - Tap "Import Certificate from AltStore/SideStore"
 - AltStore/SideStore will be opened and ask if you want to export the certificate. If you don't see the prompt, keep AltStore/SideStore open in the background and tap "Import Certificate from AltStore/SideStore" again.


### PR DESCRIPTION
Removes “nightly” now that SideStore has been updated, and removes the extra “body: |” in the Nightly Release notes from the build workflow