### PR TITLE
feat: Add JIT Script Support on a Per-App Basis for StikDebug on iOS 26+

### DIFF
--- a/LiveContainerSwiftUI/LCAppBanner.swift
+++ b/LiveContainerSwiftUI/LCAppBanner.swift
@@ -14,8 +14,6 @@ protocol LCAppBannerDelegate {
     func removeApp(app: LCAppModel)
     func installMdm(data: Data)
     func openNavigationView(view: AnyView)
-    func jitLaunch() async
-    func jitLaunch(withScript script: String?) async
 }
 
 struct LCAppBanner : View {

--- a/LiveContainerSwiftUI/LCAppBanner.swift
+++ b/LiveContainerSwiftUI/LCAppBanner.swift
@@ -309,14 +309,7 @@ struct LCAppBanner : View {
         }
 
         do {
-            // If the app requires JIT and we have a script, use the delegate to handle JIT launch with script
-            if (appInfo.isJITNeeded || appInfo.is32bit), 
-               let scriptData = model.jitLaunchScriptJs, 
-               !scriptData.isEmpty {
-                await delegate.jitLaunch(withScript: scriptData)
-            } else {
-                try await model.runApp(multitask: multitask)
-            }
+            try await model.runApp(multitask: multitask)
         } catch {
             errorInfo = error.localizedDescription
             errorShow = true

--- a/LiveContainerSwiftUI/LCAppBanner.swift
+++ b/LiveContainerSwiftUI/LCAppBanner.swift
@@ -313,7 +313,7 @@ struct LCAppBanner : View {
         do {
             // If the app requires JIT and we have a script, use the delegate to handle JIT launch with script
             if (appInfo.isJITNeeded || appInfo.is32bit), 
-               let scriptData = model.JITLaunchScriptJs, 
+               let scriptData = model.jitLaunchScriptJs, 
                !scriptData.isEmpty {
                 await delegate.jitLaunch(withScript: scriptData)
             } else {

--- a/LiveContainerSwiftUI/LCAppBanner.swift
+++ b/LiveContainerSwiftUI/LCAppBanner.swift
@@ -14,6 +14,8 @@ protocol LCAppBannerDelegate {
     func removeApp(app: LCAppModel)
     func installMdm(data: Data)
     func openNavigationView(view: AnyView)
+    func jitLaunch() async
+    func jitLaunch(withScript script: String?) async
 }
 
 struct LCAppBanner : View {
@@ -309,7 +311,14 @@ struct LCAppBanner : View {
         }
 
         do {
-            try await model.runApp(multitask: multitask)
+            // If the app requires JIT and we have a script, use the delegate to handle JIT launch with script
+            if (appInfo.isJITNeeded || appInfo.is32bit), 
+               let scriptData = model.JITLaunchScriptJs, 
+               !scriptData.isEmpty {
+                await delegate.jitLaunch(withScript: scriptData)
+            } else {
+                try await model.runApp(multitask: multitask)
+            }
         } catch {
             errorInfo = error.localizedDescription
             errorShow = true

--- a/LiveContainerSwiftUI/LCAppInfo.h
+++ b/LiveContainerSwiftUI/LCAppInfo.h
@@ -34,7 +34,7 @@ typedef NS_ENUM(NSInteger, LCOrientationLock){
 @property bool autoSaveDisabled;
 @property bool dontSign;
 @property bool spoofSDKVersion;
-@property (nonatomic, strong) NSString* JITLaunchScriptJs;
+@property (nonatomic, strong) NSString* jitLaunchScriptJs;
 @property NSDate* lastLaunched;
 @property NSDate* installationDate;
 

--- a/LiveContainerSwiftUI/LCAppInfo.h
+++ b/LiveContainerSwiftUI/LCAppInfo.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSInteger, LCOrientationLock){
 @property bool autoSaveDisabled;
 @property bool dontSign;
 @property bool spoofSDKVersion;
+@property (nonatomic, strong) NSString* JITLaunchScriptJs;
 @property NSDate* lastLaunched;
 @property NSDate* installationDate;
 

--- a/LiveContainerSwiftUI/LCAppInfo.m
+++ b/LiveContainerSwiftUI/LCAppInfo.m
@@ -620,7 +620,7 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     return _info[@"jitLaunchScriptJs"];
 }
 
-- (void)setjitLaunchScriptJs:(NSString *)jitLaunchScriptJs {
+- (void)setJitLaunchScriptJs:(NSString *)jitLaunchScriptJs {
     if (jitLaunchScriptJs.length > 0) {
         _info[@"jitLaunchScriptJs"] = jitLaunchScriptJs;
     } else {

--- a/LiveContainerSwiftUI/LCAppInfo.m
+++ b/LiveContainerSwiftUI/LCAppInfo.m
@@ -44,7 +44,8 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
                 @"LCOrientationLock",
                 @"cachedColor",
                 @"LCContainers",
-                @"hideLiveContainer"
+                @"hideLiveContainer",
+                @"JITLaunchScriptJs"
             ];
             for(NSString* key in lcAppInfoKeys) {
                 _info[key] = _infoPlist[key];
@@ -613,6 +614,19 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     _info[@"dontSign"] = [NSNumber numberWithBool:dontSign];
     [self save];
     
+}
+
+- (NSString *)JITLaunchScriptJs {
+    return _info[@"JITLaunchScriptJs"];
+}
+
+- (void)setJITLaunchScriptJs:(NSString *)JITLaunchScriptJs {
+    if (JITLaunchScriptJs.length > 0) {
+        _info[@"JITLaunchScriptJs"] = JITLaunchScriptJs;
+    } else {
+        [_info removeObjectForKey:@"JITLaunchScriptJs"];
+    }
+    if (!_autoSaveDisabled) [self save];
 }
 
 - (bool)spoofSDKVersion {

--- a/LiveContainerSwiftUI/LCAppInfo.m
+++ b/LiveContainerSwiftUI/LCAppInfo.m
@@ -45,7 +45,7 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
                 @"cachedColor",
                 @"LCContainers",
                 @"hideLiveContainer",
-                @"JITLaunchScriptJs"
+                @"jitLaunchScriptJs"
             ];
             for(NSString* key in lcAppInfoKeys) {
                 _info[key] = _infoPlist[key];
@@ -616,15 +616,15 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     
 }
 
-- (NSString *)JITLaunchScriptJs {
-    return _info[@"JITLaunchScriptJs"];
+- (NSString *)jitLaunchScriptJs {
+    return _info[@"jitLaunchScriptJs"];
 }
 
-- (void)setJITLaunchScriptJs:(NSString *)JITLaunchScriptJs {
-    if (JITLaunchScriptJs.length > 0) {
-        _info[@"JITLaunchScriptJs"] = JITLaunchScriptJs;
+- (void)setjitLaunchScriptJs:(NSString *)jitLaunchScriptJs {
+    if (jitLaunchScriptJs.length > 0) {
+        _info[@"jitLaunchScriptJs"] = jitLaunchScriptJs;
     } else {
-        [_info removeObjectForKey:@"JITLaunchScriptJs"];
+        [_info removeObjectForKey:@"jitLaunchScriptJs"];
     }
     if (!_autoSaveDisabled) [self save];
 }

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -960,7 +960,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     // New overloads: perform JIT enable via stikjit URL using the PID from LiveProcess
     func jitLaunch(withPID pid: Int) async {
         await MainActor.run {
-            if let url = URL(string: "stikjit://enable-jit?pid=\(pid)") {
+            if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)pid=\(pid)") {
                 UIApplication.shared.open(url)
             }
         }
@@ -969,7 +969,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     func jitLaunch(withPID pid: Int, withScript script: String) async {
         await MainActor.run {
             let encoded = script.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-            if let url = URL(string: "stikjit://enable-jit?pid=\(pid)&script-data=\(encoded)") {
+            if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)&pid=\(pid)&script-data=\(encoded)") {
                 UIApplication.shared.open(url)
             }
         }

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -957,6 +957,28 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         LCUtils.launchToGuestApp()
     }
     
+    // New overloads: perform JIT enable via stikjit URL using the PID from LiveProcess
+    func jitLaunch(withPID pid: Int) async {
+        await MainActor.run {
+            if let url = URL(string: "stikjit://enable-jit?pid=\(pid)") {
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url)
+                }
+            }
+        }
+    }
+    
+    func jitLaunch(withPID pid: Int, withScript script: String) async {
+        await MainActor.run {
+            let encoded = script.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+            if let url = URL(string: "stikjit://enable-jit?pid=\(pid)&script-data=\(encoded)") {
+                if UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url)
+                }
+            }
+        }
+    }
+    
     func showRunWhenMultitaskAlert() async -> Bool? {
         return await runWhenMultitaskAlert.open()
     }

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -932,17 +932,20 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     }
     
     func jitLaunch() async {
+        await jitLaunch(withScript: nil)
+    }
+    
+    func jitLaunch(withScript script: String?) async {
         await MainActor.run {
             jitLog = ""
         }
         let enableJITTask = Task {
-            let _ = await LCUtils.askForJIT { newMsg in
+            let _ = await LCUtils.askForJIT(withScript: script) { newMsg in
                 Task { await MainActor.run {
                     self.jitLog += "\(newMsg)\n"
                 }}
             }
-            guard
-                  let _ = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")) else {
+            guard let _ = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")) else {
                 return
             }
         }
@@ -952,7 +955,6 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             return
         }
         LCUtils.launchToGuestApp()
-
     }
     
     func showRunWhenMultitaskAlert() async -> Bool? {

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -961,9 +961,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     func jitLaunch(withPID pid: Int) async {
         await MainActor.run {
             if let url = URL(string: "stikjit://enable-jit?pid=\(pid)") {
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url)
-                }
+                UIApplication.shared.open(url)
             }
         }
     }
@@ -972,9 +970,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         await MainActor.run {
             let encoded = script.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
             if let url = URL(string: "stikjit://enable-jit?pid=\(pid)&script-data=\(encoded)") {
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url)
-                }
+                UIApplication.shared.open(url)
             }
         }
     }

--- a/LiveContainerSwiftUI/LCAppListView.swift
+++ b/LiveContainerSwiftUI/LCAppListView.swift
@@ -932,10 +932,10 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     }
     
     func jitLaunch() async {
-        await jitLaunch(withScript: nil)
+        await jitLaunch(withScript: "")
     }
     
-    func jitLaunch(withScript script: String?) async {
+    func jitLaunch(withScript script: String) async {
         await MainActor.run {
             jitLog = ""
         }

--- a/LiveContainerSwiftUI/LCAppModel.swift
+++ b/LiveContainerSwiftUI/LCAppModel.swift
@@ -91,9 +91,9 @@ class LCAppModel: ObservableObject, Hashable {
         }
     }
     
-    @Published var JITLaunchScriptJs: String? {
+    @Published var jitLaunchScriptJs: String? {
         didSet {
-            appInfo.JITLaunchScriptJs = JITLaunchScriptJs
+            appInfo.jitLaunchScriptJs = jitLaunchScriptJs
         }
     }
     
@@ -133,7 +133,7 @@ class LCAppModel: ObservableObject, Hashable {
         self.uiTweakLoaderInjectFailed = appInfo.info()["LCTweakLoaderCantInject"] as? Bool ?? false
         self.uiDontLoadTweakLoader = appInfo.dontLoadTweakLoader
         self.uiDontSign = appInfo.dontSign
-        self.JITLaunchScriptJs = appInfo.JITLaunchScriptJs
+        self.jitLaunchScriptJs = appInfo.jitLaunchScriptJs
         self.uiSpoofSDKVersion = appInfo.spoofSDKVersion
         
         self.uiIs32bit = appInfo.is32bit
@@ -237,7 +237,7 @@ class LCAppModel: ObservableObject, Hashable {
 
         if appInfo.isJITNeeded || appInfo.is32bit {
             // Pass the JIT script data to the delegate if available
-            if let scriptData = JITLaunchScriptJs, !scriptData.isEmpty {
+            if let scriptData = jitLaunchScriptJs, !scriptData.isEmpty {
                 await delegate?.jitLaunch(withScript: scriptData)
             } else {
                 await delegate?.jitLaunch()

--- a/LiveContainerSwiftUI/LCAppModel.swift
+++ b/LiveContainerSwiftUI/LCAppModel.swift
@@ -238,7 +238,7 @@ class LCAppModel: ObservableObject, Hashable {
             // For JIT apps launched in multitask, first open in LiveProcess, then enable JIT by PID
             if multitask, #available(iOS 16.0, *) {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    LCUtils.launchMultitaskGuestAppWithPIDCallback(appInfo.displayName()) { pidNumber, error in
+                    LCUtils.launchMultitaskGuestApp(withPIDCallback: appInfo.displayName(), pidCompletionHandler: { pidNumber, error in
                         if let error {
                             continuation.resume(throwing: error)
                             return
@@ -255,7 +255,7 @@ class LCAppModel: ObservableObject, Hashable {
                             }
                             continuation.resume()
                         }
-                    }
+                    })
                 }
             } else {
                 // Non-multitask JIT flow remains unchanged

--- a/LiveContainerSwiftUI/LCAppModel.swift
+++ b/LiveContainerSwiftUI/LCAppModel.swift
@@ -238,7 +238,7 @@ class LCAppModel: ObservableObject, Hashable {
             // For JIT apps launched in multitask, first open in LiveProcess, then enable JIT by PID
             if multitask, #available(iOS 16.0, *) {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                    LCUtils.launchMultitaskGuestApp(appInfo.displayName()) { pidNumber, error in
+                    LCUtils.launchMultitaskGuestAppWithPIDCallback(appInfo.displayName()) { pidNumber, error in
                         if let error {
                             continuation.resume(throwing: error)
                             return

--- a/LiveContainerSwiftUI/LCAppModel.swift
+++ b/LiveContainerSwiftUI/LCAppModel.swift
@@ -5,6 +5,8 @@ protocol LCAppModelDelegate {
     func changeAppVisibility(app : LCAppModel)
     func jitLaunch() async
     func jitLaunch(withScript script: String) async
+    func jitLaunch(withPID pid: Int) async
+    func jitLaunch(withPID pid: Int, withScript script: String) async
     func showRunWhenMultitaskAlert() async -> Bool?
 }
 
@@ -160,9 +162,6 @@ class LCAppModel: ObservableObject, Hashable {
         }
         
         var multitask = multitask
-        if(appInfo.isJITNeeded && multitask) {
-            multitask = false
-        }
         
         if multitask && !uiIsShared {
             throw "It's not possible to multitask with private apps."
@@ -236,11 +235,35 @@ class LCAppModel: ObservableObject, Hashable {
         UserDefaults.standard.set(uiSelectedContainer?.folderName, forKey: "selectedContainer")
 
         if appInfo.isJITNeeded || appInfo.is32bit {
-            // Pass the JIT script data to the delegate if available
-            if let scriptData = jitLaunchScriptJs, !scriptData.isEmpty {
-                await delegate?.jitLaunch(withScript: scriptData)
+            // For JIT apps launched in multitask, first open in LiveProcess, then enable JIT by PID
+            if multitask, #available(iOS 16.0, *) {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    LCUtils.launchMultitaskGuestApp(appInfo.displayName()) { pidNumber, error in
+                        if let error {
+                            continuation.resume(throwing: error)
+                            return
+                        }
+                        guard let pidNumber = pidNumber else {
+                            continuation.resume(throwing: "Failed to obtain PID from LiveProcess")
+                            return
+                        }
+                        Task {
+                            if let scriptData = self.jitLaunchScriptJs, !scriptData.isEmpty {
+                                await self.delegate?.jitLaunch(withPID: pidNumber.intValue, withScript: scriptData)
+                            } else {
+                                await self.delegate?.jitLaunch(withPID: pidNumber.intValue)
+                            }
+                            continuation.resume()
+                        }
+                    }
+                }
             } else {
-                await delegate?.jitLaunch()
+                // Non-multitask JIT flow remains unchanged
+                if let scriptData = jitLaunchScriptJs, !scriptData.isEmpty {
+                    await delegate?.jitLaunch(withScript: scriptData)
+                } else {
+                    await delegate?.jitLaunch()
+                }
             }
         } else if multitask, #available(iOS 16.0, *) {
             try await LCUtils.launchMultitaskGuestApp(appInfo.displayName())

--- a/LiveContainerSwiftUI/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/LCAppSettingsView.swift
@@ -143,7 +143,7 @@ struct LCAppSettingsView: View {
                     HStack {
                         Text("JIT Launch Script")
                         Spacer()
-                        if let base64String = model.JITLaunchScriptJs, !base64String.isEmpty {
+                        if let base64String = model.jitLaunchScriptJs, !base64String.isEmpty {
                             // Show a generic name since we're not storing the filename
                             Text("Script Loaded")
                                 .lineLimit(1)
@@ -151,7 +151,7 @@ struct LCAppSettingsView: View {
                                 .foregroundColor(.primary)
                             
                             Button(action: {
-                                model.JITLaunchScriptJs = nil
+                                model.jitLaunchScriptJs = nil
                             }) {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundColor(.gray)
@@ -169,7 +169,7 @@ struct LCAppSettingsView: View {
                                 do {
                                     let data = try Data(contentsOf: url)
                                     // Store the Base64-encoded string of the file content
-                                    model.JITLaunchScriptJs = data.base64EncodedString()
+                                    model.jitLaunchScriptJs = data.base64EncodedString()
                                 } catch {
                                     errorInfo = "Failed to read file: \(error.localizedDescription)"
                                     errorShow = true

--- a/LiveContainerSwiftUI/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/LCAppSettingsView.swift
@@ -7,8 +7,20 @@
 
 import Foundation
 import SwiftUI
+import UIKit
+import UniformTypeIdentifiers
 
-struct LCAppSettingsView : View{
+struct LCAppSettingsView: View {
+    @State private var documentPickerCoordinator = DocumentPickerCoordinator()
+    
+    private class DocumentPickerCoordinator: NSObject, UIDocumentPickerDelegate {
+        var onDocumentPicked: ((URL) -> Void)?
+        
+        func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+            guard let url = urls.first else { return }
+            onDocumentPicked?(url)
+        }
+    }
     
     private var appInfo : LCAppInfo
     
@@ -126,8 +138,64 @@ struct LCAppSettingsView : View{
                 Toggle(isOn: $model.uiIsJITNeeded) {
                     Text("lc.appSettings.launchWithJit".loc)
                 }
+                
+                if #available(iOS 26.0, *) {
+                    HStack {
+                        Text("JIT Launch Script")
+                        Spacer()
+                        if let base64String = model.JITLaunchScriptJs, !base64String.isEmpty {
+                            // Show a generic name since we're not storing the filename
+                            Text("Script Loaded")
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .foregroundColor(.primary)
+                            
+                            Button(action: {
+                                model.JITLaunchScriptJs = nil
+                            }) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.gray)
+                            }
+                            .buttonStyle(BorderlessButtonStyle())
+                        } else {
+                            Text("No file selected")
+                                .foregroundColor(.gray)
+                        }
+                        Button(action: {
+                            // This will trigger the file picker
+                            let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.javaScript], asCopy: true)
+                            picker.allowsMultipleSelection = false
+                            documentPickerCoordinator.onDocumentPicked = { url in
+                                do {
+                                    let data = try Data(contentsOf: url)
+                                    // Store the Base64-encoded string of the file content
+                                    model.JITLaunchScriptJs = data.base64EncodedString()
+                                } catch {
+                                    errorInfo = "Failed to read file: \(error.localizedDescription)"
+                                    errorShow = true
+                                }
+                            }
+                            picker.delegate = documentPickerCoordinator
+                            
+                            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                               let rootViewController = windowScene.windows.first?.rootViewController {
+                                rootViewController.present(picker, animated: true)
+                            }
+                        }) {
+                            Text("Select")
+                        }
+                        .disabled(!model.uiIsJITNeeded)
+                    }
+                }
             } footer: {
-                Text("lc.appSettings.launchWithJitDesc".loc)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("lc.appSettings.launchWithJitDesc".loc)
+                    if #available(iOS 26.0, *) {
+                        Text("Optional JavaScript file to run when JIT launching the app")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
             }
 
             Section {

--- a/LiveContainerSwiftUI/LCUtils.h
+++ b/LiveContainerSwiftUI/LCUtils.h
@@ -32,6 +32,7 @@ int dyld_get_program_sdk_version(void);
 + (BOOL)launchToGuestApp;
 + (BOOL)launchToGuestAppWithURL:(NSURL *)url;
 + (void)launchMultitaskGuestApp:(NSString *)displayName completionHandler:(void (^)(NSError *error))completionHandler API_AVAILABLE(ios(16.0));
++ (void)launchMultitaskGuestApp:(NSString *)displayName pidCompletionHandler:(void (^)(NSNumber *pid, NSError *error))completionHandler API_AVAILABLE(ios(16.0));
 + (NSString*)getContainerUsingLCSchemeWithFolderName:(NSString*)folderName;
 
 + (NSProgress *)signAppBundleWithZSign:(NSURL *)path completionHandler:(void (^)(BOOL success, NSError *error))completionHandler;

--- a/LiveContainerSwiftUI/LCUtils.h
+++ b/LiveContainerSwiftUI/LCUtils.h
@@ -32,7 +32,7 @@ int dyld_get_program_sdk_version(void);
 + (BOOL)launchToGuestApp;
 + (BOOL)launchToGuestAppWithURL:(NSURL *)url;
 + (void)launchMultitaskGuestApp:(NSString *)displayName completionHandler:(void (^)(NSError *error))completionHandler API_AVAILABLE(ios(16.0));
-+ (void)launchMultitaskGuestApp:(NSString *)displayName pidCompletionHandler:(void (^)(NSNumber *pid, NSError *error))completionHandler API_AVAILABLE(ios(16.0));
++ (void)launchMultitaskGuestAppWithPIDCallback:(NSString *)displayName pidCompletionHandler:(void (^)(NSNumber *pid, NSError *error))completionHandler API_AVAILABLE(ios(16.0));
 + (NSString*)getContainerUsingLCSchemeWithFolderName:(NSString*)folderName;
 
 + (NSProgress *)signAppBundleWithZSign:(NSURL *)path completionHandler:(void (^)(BOOL success, NSError *error))completionHandler;

--- a/LiveContainerSwiftUI/LCUtils.m
+++ b/LiveContainerSwiftUI/LCUtils.m
@@ -24,7 +24,7 @@ Class LCSharedUtilsClass = nil;
 + (void)load {
     LCSharedUtilsClass = NSClassFromString(@"LCSharedUtils");
 }
-+ (void)launchMultitaskGuestApp:(NSString *)displayName pidCompletionHandler:(void (^)(NSNumber *pid, NSError *error))completionHandler {
++ (void)launchMultitaskGuestAppWithPIDCallback:(NSString *)displayName pidCompletionHandler:(void (^)(NSNumber *pid, NSError *error))completionHandler {
     NSBundle *liveProcessBundle = [NSBundle bundleWithPath:[NSBundle.mainBundle.builtInPlugInsPath stringByAppendingPathComponent:@"LiveProcess.appex"]];
     if(!liveProcessBundle) {
         NSError *error = [NSError errorWithDomain:displayName code:2 userInfo:@{NSLocalizedDescriptionKey: @"LiveProcess extension not found. Please reinstall LiveContainer and select Keep Extensions"}];

--- a/LiveContainerSwiftUI/LCUtils.m
+++ b/LiveContainerSwiftUI/LCUtils.m
@@ -24,6 +24,36 @@ Class LCSharedUtilsClass = nil;
 + (void)load {
     LCSharedUtilsClass = NSClassFromString(@"LCSharedUtils");
 }
++ (void)launchMultitaskGuestApp:(NSString *)displayName pidCompletionHandler:(void (^)(NSNumber *pid, NSError *error))completionHandler {
+    NSBundle *liveProcessBundle = [NSBundle bundleWithPath:[NSBundle.mainBundle.builtInPlugInsPath stringByAppendingPathComponent:@"LiveProcess.appex"]];
+    if(!liveProcessBundle) {
+        NSError *error = [NSError errorWithDomain:displayName code:2 userInfo:@{NSLocalizedDescriptionKey: @"LiveProcess extension not found. Please reinstall LiveContainer and select Keep Extensions"}];
+        if (completionHandler) completionHandler(nil, error);
+        return;
+    }
+
+    NSUserDefaults *lcUserDefaults = NSUserDefaults.standardUserDefaults;
+    NSString* bundleId = [lcUserDefaults stringForKey:@"selected"];
+    NSString* dataUUID = [lcUserDefaults stringForKey:@"selectedContainer"];
+
+    [lcUserDefaults removeObjectForKey:@"selected"];
+    [lcUserDefaults removeObjectForKey:@"selectedContainer"];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *rootVC = ((UIWindowScene *)UIApplication.sharedApplication.connectedScenes.anyObject).keyWindow.rootViewController;
+        DecoratedAppSceneViewController *launcherView = [[DecoratedAppSceneViewController alloc] initWindowName:displayName bundleId:bundleId dataUUID:dataUUID];
+        // Wire PID callback
+        launcherView.pidAvailableHandler = ^(NSNumber *pid, NSError *error) {
+            if (completionHandler) {
+                completionHandler(pid, error);
+            }
+        };
+        launcherView.view.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
+        launcherView.view.center = rootVC.view.center;
+        [rootVC addChildViewController:launcherView];
+        [rootVC.view addSubview:launcherView.view];
+    });
+}
 
 #pragma mark Certificate & password
 + (NSString *)teamIdentifier {

--- a/LiveContainerSwiftUI/Shared.swift
+++ b/LiveContainerSwiftUI/Shared.swift
@@ -812,7 +812,7 @@ extension LCUtils {
         }
     }
     
-    public static func askForJIT(onServerMessage : ((String) -> Void)? ) async -> Bool {
+    public static func askForJIT(withScript script: String? = nil, onServerMessage: ((String) -> Void)? = nil) async -> Bool {
         // if LiveContainer is installed by TrollStore
         let tsPath = "\(Bundle.main.bundlePath)/../_TrollStore"
         if (access((tsPath as NSString).utf8String, 0) == 0) {
@@ -900,7 +900,12 @@ extension LCUtils {
             }
             
         } else if jitEnabler == .StkiJIT || jitEnabler == .StikJITLC {
-            let launchURLStr = "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)"
+            var launchURLStr = "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)"
+            
+            // Add JIT script data if available
+            if let script = script, !script.isEmpty {
+                launchURLStr += "&script-data=\(script)"
+            }
             let launchURL : URL
             if jitEnabler == .StikJITLC {
                 let encodedStr = Data(launchURLStr.utf8).base64EncodedString()

--- a/MultitaskSupport/DecoratedAppSceneViewController.h
+++ b/MultitaskSupport/DecoratedAppSceneViewController.h
@@ -16,5 +16,6 @@ API_AVAILABLE(ios(16.0))
 - (void)minimizeWindowPiP;
 - (void)unminimizeWindowPiP;
 - (void)updateVerticalConstraints;
+@property(nonatomic, copy) void (^pidAvailableHandler)(NSNumber *pid, NSError *error);
 @end
 

--- a/MultitaskSupport/DecoratedAppSceneViewController.m
+++ b/MultitaskSupport/DecoratedAppSceneViewController.m
@@ -344,9 +344,15 @@ void UIKitFixesInit(void) {
                 UIPasteboard.generalPasteboard.string = error.localizedDescription;
             }]];
             [self presentViewController:alert animated:YES completion:nil];
+            if (self.pidAvailableHandler) {
+                self.pidAvailableHandler(nil, error);
+            }
         } else {
             self.pid = vc.pid;
             [self updateOriginalFrame];
+            if (self.pidAvailableHandler) {
+                self.pidAvailableHandler(@(self.pid), nil);
+            }
         }
     });
 }


### PR DESCRIPTION
This PR introduces support for running custom JavaScript scripts during JIT launch when using StikDebug on iOS 26 and later.

Key Changes:
- Added a new file picker UI in app settings to select JavaScript files for JIT launch
- Implemented script data passing to StikDebug via URL parameters
- Added proper error handling and user feedback for script selection
- Updated the JIT launch flow to include optional script execution