### PR TITLE
Lang(de): Update and improve translations

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -109,7 +109,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Einige Anwendungen werden im Multitasking-Modus ausgeführt. Wenn Sie diese Anwendung ausführen, werden laufende Anwendungen beendet. Fortfahren?"
+            "value" : "Einige Anwendungen werden im Multitasking-Modus ausgeführt. Wenn Sie diese Anwendung starten, werden laufende Anwendungen beendet. Fortfahren?"
           }
         },
         "en" : {
@@ -584,7 +584,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Möchten Sie außerdem den Datenordner von %@ löschen? Sie können ihn für spätere Verwendung behalten."
+            "value" : "Möchten Sie außerdem den Datenordner von %@ löschen? Sie können ihn für eine spätere Verwendung behalten."
           }
         },
         "en" : {
@@ -2017,7 +2017,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Initialisierung der Anwendungs-Info fehlgeschlagen!"
+            "value" : "Initialisierung der Anwendungsinformationen fehlgeschlagen!"
           }
         },
         "en" : {


### PR DESCRIPTION
I have updated almost every German translation because they were really bad previously. Many had grammatical errors or words were missing. I also tried to be as consistent as possible and for example replaced "app" with "Anwendung" because it was mixed before. Same thing with "fortsetzen" and "fortfahren" and so on