### PR TITLE
Fix Run button hit area

### DIFF
--- a/LiveContainerSwiftUI/Views/AppList/LCAppBanner.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppBanner.swift
@@ -176,6 +176,7 @@ struct LCAppBanner : View {
 
             })
             .clipShape(Capsule())
+            .contentShape(Capsule())
             .disabled(model.isAppRunning)
         }
         .padding()


### PR DESCRIPTION
The run button doesn't detect touch input on the empty spaces like padding. I find that it only work when I touch the "Run" text itself. This makes the whole capsule accept touch input