### PR TITLE
Add StosDebug support and make JITEnablerType CaseIterable

### DIFF
--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -3,9 +3,9 @@ import Foundation
 protocol LCAppModelDelegate {
     func closeNavigationView()
     func changeAppVisibility(app : LCAppModel)
-    func jitLaunch() async
-    func jitLaunch(withScript script: String) async
-    func jitLaunch(withPID pid: Int, withScript script: String?) async
+    func jitLaunch(appName: String) async
+    func jitLaunch(withScript script: String, appName: String) async
+    func jitLaunch(withPID pid: Int, withScript script: String?, appName: String) async
     func showRunWhenMultitaskAlert() async -> Bool?
 }
 
@@ -262,9 +262,9 @@ class LCAppModel: ObservableObject, Hashable {
                         }
                         Task {
                             if let scriptData = self.jitLaunchScriptJs, !scriptData.isEmpty {
-                                await self.delegate?.jitLaunch(withPID: pidNumber.intValue, withScript: scriptData)
+                                await self.delegate?.jitLaunch(withPID: pidNumber.intValue, withScript: scriptData, appName: self.appInfo.displayName())
                             } else {
-                                await self.delegate?.jitLaunch(withPID: pidNumber.intValue, withScript: nil)
+                                await self.delegate?.jitLaunch(withPID: pidNumber.intValue, withScript: nil, appName: self.appInfo.displayName())
                             }
                             continuation.resume()
                         }
@@ -273,9 +273,9 @@ class LCAppModel: ObservableObject, Hashable {
             } else {
                 // Non-multitask JIT flow remains unchanged
                 if let scriptData = jitLaunchScriptJs, !scriptData.isEmpty {
-                    await delegate?.jitLaunch(withScript: scriptData)
+                    await delegate?.jitLaunch(withScript: scriptData, appName: self.appInfo.displayName())
                 } else {
-                    await delegate?.jitLaunch()
+                    await delegate?.jitLaunch(appName: self.appInfo.displayName())
                 }
             }
         } else if multitask, #available(iOS 16.0, *) {

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -391,7 +391,59 @@ extension LCUtils {
                 launchURLStr += "&script=\(script)"
             }
             
-            await UIApplication.shared.open(URL(string: launchURLStr)!)
+            if jitEnabler == .StosDebugLC {
+                let encodedStr = Data(launchURLStr.utf8).base64EncodedString()
+
+
+                var appToLaunch: LCAppModel? = nil
+                // find an app that can respond to stikjit://
+                appLoop:
+                for app in DataManager.shared.model.apps {
+                    if let schemes = app.appInfo.urlSchemes() {
+                        for scheme in schemes {
+                            if let scheme = scheme as? String, scheme == "stosdebug" {
+                                appToLaunch = app
+                                break appLoop
+                            }
+                        }
+                    }
+                }
+                guard let appToLaunch else {
+                    onServerMessage?("StosDebug is not installed in LiveContainer.")
+                    return false
+                }
+                
+                if !appToLaunch.uiIsShared {
+                    onServerMessage?("StosDebug is installed in LiveContainer, but is not a shared app. Convert it to a shared app to continue.")
+                    return false
+                }
+                // check if stosdebug is already running
+                var freeScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
+                
+                if(freeScheme == nil) {
+                    // if not, try to find a free lc
+                    forEachInstalledLC(isFree: true) { scheme, shouldBreak in
+                        freeScheme = scheme
+                        shouldBreak = true
+                    }
+                }
+                guard let freeScheme else {
+                    onServerMessage?("No free LiveContainer is available. Please either: \n(1)close one, \n(2)install a new one, \n(3)choose another method to enable JIT.")
+                    return false
+                }
+                
+                let launchURL = URL(string: "\(freeScheme)://open-url?url=\(encodedStr)")!
+                
+                LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath, forKey: "LCLaunchExtensionBundleID")
+                LCUtils.appGroupUserDefault.set(Date.now, forKey: "LCLaunchExtensionLaunchDate")
+                onServerMessage?("JIT acquisition will continue in another LiveContainer.")
+                
+                await UIApplication.shared.open(launchURL)
+            } else {
+                onServerMessage?("JIT acquisition will continue in StosDebug.")
+                
+                await UIApplication.shared.open(URL(string: launchURLStr)!)
+            }
             
         } else if jitEnabler == .StikJIT || jitEnabler == .StikJITLC {
             var launchURLStr = "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)"

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -298,7 +298,7 @@ extension LCUtils {
         }
     }
     
-    public static func askForJIT(withScript script: String? = nil, onServerMessage: ((String) -> Void)? = nil) async -> Bool {
+    public static func askForJIT(withScript script: String? = nil, appName: String? = nil, onServerMessage: ((String) -> Void)? = nil) async -> Bool {
         // if LiveContainer is installed by TrollStore
         let tsPath = "\(Bundle.main.bundlePath)/../_TrollStore"
         if (access((tsPath as NSString).utf8String, 0) == 0) {
@@ -310,7 +310,6 @@ extension LCUtils {
               let jitEnabler = JITEnablerType(rawValue: groupUserDefaults.integer(forKey: "LCJITEnablerType")) else {
             return false
         }
-        
         
         if(jitEnabler == .SideJITServer){
             guard
@@ -346,7 +345,7 @@ extension LCUtils {
             onServerMessage?("Please make sure the VPN is connected if the server is not in your local network.")
             
             do {
-
+                
                 onServerMessage?("Contacting JitStreamer-EB server at \(JITStresmerEBAddress)...")
                 
                 let session = URLSession.shared
@@ -380,10 +379,19 @@ extension LCUtils {
                 }
                 return false
                 
-
+                
             } catch {
                 onServerMessage?("Failed to contact JitStreamer-EB server: \(error)")
             }
+        } else if jitEnabler == .StosDebug || jitEnabler == .StosDebugLC {
+            guard let appName else { onServerMessage?("Unable to get App Name, Please try again."); return false }
+            var launchURLStr = "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)"
+            
+            if let script = script, !script.isEmpty {
+                launchURLStr += "&script=\(script)"
+            }
+            
+            await UIApplication.shared.open(URL(string: launchURLStr)!)
             
         } else if jitEnabler == .StkiJIT || jitEnabler == .StikJITLC {
             var launchURLStr = "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)"

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -393,7 +393,7 @@ extension LCUtils {
             
             await UIApplication.shared.open(URL(string: launchURLStr)!)
             
-        } else if jitEnabler == .StkiJIT || jitEnabler == .StikJITLC {
+        } else if jitEnabler == .StikJIT || jitEnabler == .StikJITLC {
             var launchURLStr = "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)"
 
             if let script = script, !script.isEmpty {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1106,10 +1106,11 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return
                         }
                     } else {
-                        if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)\(encoded)") {
+                        if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&forcePID=true\(encoded)") {
                             UIApplication.shared.open(url)
                         }
                     }
+                    return
                 }
                 
                 let encoded = encodedData.map { "&script-data=\($0)" } ?? ""

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1056,16 +1056,17 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         }
     }
     
-    func jitLaunch() async {
-        await jitLaunch(withScript: "")
+    func jitLaunch(appName: String) async {
+        await jitLaunch(withScript: "", appName: appName)
     }
 
-    func jitLaunch(withScript script: String) async {
+    func jitLaunch(withScript script: String, appName: String) async {
         await MainActor.run {
             jitLog = ""
         }
         let enableJITTask = Task {
-            let _ = await LCUtils.askForJIT(withScript: script) { newMsg in
+            
+            let _ = await LCUtils.askForJIT(withScript: script, appName: appName) { newMsg in
                 Task { await MainActor.run {
                     self.jitLog += "\(newMsg)\n"
                 }}
@@ -1083,24 +1084,50 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
 
     }
     
-    func jitLaunch(withPID pid: Int, withScript script: String? = nil) async {
+    func jitLaunch(withPID pid: Int, withScript script: String? = nil, appName: String) async {
         await MainActor.run {
-            let encoded = script?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                .map { "&script-data=\($0)" } ?? ""
-            if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)&pid=\(pid)\(encoded)") {
-                if let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")), jitEnabler == .StikJITLC {
-                    if let app = sharedModel.apps.first(where: { app in
-                        return app.appInfo.urlSchemes().contains("stikjit") &&
-                        (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
-                    }) {
-                        Task { await openWebView(urlString: url.absoluteString) }
+            let encodedData = script?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+                
+            
+            if let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")) {
+                if jitEnabler == .StosDebug || jitEnabler == .StosDebugLC {
+                    let encoded = encodedData.map { "&script=\($0)" } ?? ""
+                    if jitEnabler == .StosDebugLC {
+                        if let app = sharedModel.apps.first(where: { app in
+                            return app.appInfo.urlSchemes().contains("stosdebug") &&
+                            (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
+                        }) {
+                            if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false\(encoded)") {
+                                Task { await openWebView(urlString: url.absoluteString) }
+                            }
+                        } else {
+                            errorInfo = "StosDebug is not found. Please install it first and switch it to shared app."
+                            errorShow = true
+                            return
+                        }
                     } else {
-                        errorInfo = "StikDebug is not found. Please install it first and switch it to shared app."
-                        errorShow = true
-                        return
+                        if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)\(encoded)") {
+                            UIApplication.shared.open(url)
+                        }
                     }
-                } else {
-                    UIApplication.shared.open(url)
+                }
+                
+                let encoded = encodedData.map { "&script-data=\($0)" } ?? ""
+                if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)&pid=\(pid)\(encoded)") {
+                    if jitEnabler == .StikJITLC {
+                        if let app = sharedModel.apps.first(where: { app in
+                            return app.appInfo.urlSchemes().contains("stikjit") &&
+                            (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
+                        }) {
+                            Task { await openWebView(urlString: url.absoluteString) }
+                        } else {
+                            errorInfo = "StikDebug is not found. Please install it first and switch it to shared app."
+                            errorShow = true
+                            return
+                        }
+                    } else {
+                        UIApplication.shared.open(url)
+                    }
                 }
             }
         }

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1097,7 +1097,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return app.appInfo.urlSchemes().contains("stosdebug") &&
                             (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
                         }) {
-                            if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false\(encoded)") {
+                            if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false& forcePID=true\(encoded)") {
                                 Task { await openWebView(urlString: url.absoluteString) }
                             }
                         } else {

--- a/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
@@ -8,7 +8,8 @@
 import Foundation
 import SwiftUI
 
-enum JITEnablerType : Int, CaseIterable {
+enum JITEnablerType : Int, CaseIterable, Identifiable {
+    var id: Int { rawValue }
     case SideJITServer = 0
     case StikJIT = 1
     case JITStreamerEBLegacy = 2
@@ -181,7 +182,7 @@ struct LCSettingsView: View {
                         }
                     }
                     Picker(selection: $JITEnabler) {
-                        ForEach(JITEnablerType.allCases) { enablerType in
+                        ForEach(JITEnablerType.allCases.indicies, id: \.self) { enablerType in
                             Text(enablerType.displayName).tag(enablerType)
                         }
                     } label: {

--- a/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
@@ -15,7 +15,7 @@ enum JITEnablerType : Int {
     case StikJITLC = 3
     case SideStore = 4
     case StosDebug = 5
-    case StosDebugLC = 5
+    case StosDebugLC = 6
 }
 
 struct LCSettingsView: View {

--- a/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
@@ -182,7 +182,7 @@ struct LCSettingsView: View {
                         }
                     }
                     Picker(selection: $JITEnabler) {
-                        ForEach(JITEnablerType.allCases.indicies, id: \.self) { enablerType in
+                        ForEach(JITEnablerType.allCases) { enablerType in
                             Text(enablerType.displayName).tag(enablerType)
                         }
                     } label: {

--- a/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
@@ -14,6 +14,8 @@ enum JITEnablerType : Int {
     case JITStreamerEBLegacy = 2
     case StikJITLC = 3
     case SideStore = 4
+    case StosDebug = 5
+    case StosDebugLC = 5
 }
 
 struct LCSettingsView: View {

--- a/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
@@ -8,14 +8,26 @@
 import Foundation
 import SwiftUI
 
-enum JITEnablerType : Int {
+enum JITEnablerType : Int, CaseIterable {
     case SideJITServer = 0
-    case StkiJIT = 1
+    case StikJIT = 1
     case JITStreamerEBLegacy = 2
     case StikJITLC = 3
     case SideStore = 4
     case StosDebug = 5
     case StosDebugLC = 6
+    
+    var displayName: String {
+        switch self {
+        case .StikJIT: "StikDebug"
+        case .StikJITLC: "StikDebug (Another LiveContainer)"
+        case .StosDebug: "StosDebug"
+        case .StosDebugLC: "StosDebug (Another LiveContainer)"
+        case .SideStore: "SideStore"
+        case .JITStreamerEBLegacy: "JitStreamer-EB (Relaunch)"
+        case .SideJITServer: "SideJITServer/JITStreamer 2.0"
+        }
+    }
 }
 
 struct LCSettingsView: View {
@@ -169,11 +181,9 @@ struct LCSettingsView: View {
                         }
                     }
                     Picker(selection: $JITEnabler) {
-                        Text("SideJITServer/JITStreamer 2.0").tag(JITEnablerType.SideJITServer)
-                        Text("StikDebug").tag(JITEnablerType.StkiJIT)
-                        Text("StikDebug (Another LiveContainer)").tag(JITEnablerType.StikJITLC)
-                        Text("SideStore").tag(JITEnablerType.SideStore)
-                        Text("JitStreamer-EB (Relaunch)").tag(JITEnablerType.JITStreamerEBLegacy)
+                        ForEach(JITEnablerType.allCases) { enablerType in
+                            Text(enablerType.displayName).tag(enablerType)
+                        }
                     } label: {
                         Text("lc.settings.jitEnabler".loc)
                     }


### PR DESCRIPTION
StosDebug is a JIT Enabler i'm working on using the new rppairing protocol implemented in idevice. 

The URLScheme require's the guest app's name so it can correctly apply the script without requiring the user to select a script

Made JITEnablerType conform to CaseIterable and Identifiable to allow for a ForEach for easier changes