### PR TITLE
Add support for updating from AltSource

### DIFF
--- a/LiveContainerSwiftUI/Models/LCAppInfo.h
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.h
@@ -39,6 +39,7 @@ typedef NS_ENUM(NSInteger, LCOrientationLock){
 @property NSDate* lastLaunched;
 @property NSDate* installationDate;
 @property NSString* remark;
+@property NSString* altSource;
 #if is32BitSupported
 @property bool is32bit;
 #endif

--- a/LiveContainerSwiftUI/Models/LCAppInfo.h
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSInteger, LCOrientationLock){
 @property NSString* remark;
 @property NSString* altSource;
 @property NSString* altSourceIdentifier;
+@property bool enableUpdates;
 #if is32BitSupported
 @property bool is32bit;
 #endif

--- a/LiveContainerSwiftUI/Models/LCAppInfo.h
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, LCOrientationLock){
 @property NSDate* installationDate;
 @property NSString* remark;
 @property NSString* altSource;
+@property NSString* altSourceIdentifier;
 #if is32BitSupported
 @property bool is32bit;
 #endif

--- a/LiveContainerSwiftUI/Models/LCAppInfo.m
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.m
@@ -763,4 +763,17 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     [self save];
 }
 
+- (NSString*)altSource {
+    return _info[@"altSource"];
+}
+
+- (void)setAltSource:(NSString *)altSource {
+    if([altSource isEqualToString: @""]) {
+        _info[@"altSource"] = nil;
+    } else {
+        _info[@"altSource"] = altSource;
+    }
+    [self save];
+}
+
 @end

--- a/LiveContainerSwiftUI/Models/LCAppInfo.m
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.m
@@ -776,4 +776,17 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     [self save];
 }
 
+- (NSString*)altSourceIdentifier {
+    return _info[@"altSourceIdentifier"];
+}
+
+- (void)setAltSourceIdentifier:(NSString *)altSourceIdentifier {
+    if([altSourceIdentifier isEqualToString: @""]) {
+        _info[@"altSourceIdentifier"] = nil;
+    } else {
+        _info[@"altSourceIdentifier"] = altSourceIdentifier;
+    }
+    [self save];
+}
+
 @end

--- a/LiveContainerSwiftUI/Models/LCAppInfo.m
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.m
@@ -789,4 +789,16 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
     [self save];
 }
 
+- (bool)enableUpdates {
+    if(_info[@"enableUpdates"] != nil) {
+        return [_info[@"enableUpdates"] boolValue];
+    }
+    return true;
+}
+
+- (void)setEnableUpdates:(bool)enableUpdates {
+    _info[@"enableUpdates"] = [NSNumber numberWithBool:enableUpdates];
+    [self save];
+}
+
 @end

--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -110,6 +110,12 @@ class LCAppModel: ObservableObject, Hashable {
         }
     }
     
+    @Published var uiAltSource : String {
+        didSet {
+            appInfo.altSource = uiAltSource
+        }
+    }
+    
     @Published var supportedLanguages : [String]?
     
     var delegate : LCAppModelDelegate?
@@ -143,6 +149,7 @@ class LCAppModel: ObservableObject, Hashable {
         self.jitLaunchScriptJs = appInfo.jitLaunchScriptJs
         self.uiSpoofSDKVersion = appInfo.spoofSDKVersion
         self.uiRemark = appInfo.remark ?? ""
+        self.uiAltSource = appInfo.altSource ?? ""
 #if is32BitSupported
         self.uiIs32bit = appInfo.is32bit
 #endif

--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -116,6 +116,12 @@ class LCAppModel: ObservableObject, Hashable {
         }
     }
     
+    @Published var uiEnableUpdates : Bool {
+        didSet {
+            appInfo.enableUpdates = uiEnableUpdates
+        }
+    }
+    
     @Published var supportedLanguages : [String]?
     
     var delegate : LCAppModelDelegate?
@@ -150,6 +156,7 @@ class LCAppModel: ObservableObject, Hashable {
         self.uiSpoofSDKVersion = appInfo.spoofSDKVersion
         self.uiRemark = appInfo.remark ?? ""
         self.uiAltSource = appInfo.altSource ?? ""
+        self.uiEnableUpdates = appInfo.enableUpdates
 #if is32BitSupported
         self.uiIs32bit = appInfo.is32bit
 #endif

--- a/LiveContainerSwiftUI/Utilities/Shared.swift
+++ b/LiveContainerSwiftUI/Utilities/Shared.swift
@@ -67,6 +67,7 @@ class SharedModel: ObservableObject {
     
     @Published var apps : [LCAppModel] = []
     @Published var hiddenApps : [LCAppModel] = []
+    @Published var totalUpdateableAppsCount = 0
     
     @Published var pidCallback : ((NSNumber, Error?) -> Void)? = nil
     

--- a/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
@@ -76,6 +76,13 @@ struct LCAppSettingsView: View {
                         .multilineTextAlignment(.trailing)
                         .textSelection(.enabled)
                 }
+                if !model.uiAltSource.isEmpty {
+                    HStack {
+                        Text("lc.appSettings.enableUpdates".loc)
+                        Spacer()
+                        Toggle("", isOn: $model.uiEnableUpdates)
+                    }
+                }
                 if !model.uiIsShared {
                     Menu {
                         Picker(selection: $model.uiTweakFolder , label: Text("")) {

--- a/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
@@ -68,6 +68,14 @@ struct LCAppSettingsView: View {
                         .foregroundColor(.gray)
                         .multilineTextAlignment(.trailing)
                 }
+                HStack {
+                    Text("AltSource")
+                    Spacer()
+                    Text(model.uiAltSource.isEmpty ? "None" : model.uiAltSource)
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.trailing)
+                        .textSelection(.enabled)
+                }
                 if !model.uiIsShared {
                     Menu {
                         Picker(selection: $model.uiTweakFolder , label: Text("")) {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -755,16 +755,21 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             finalNewApp.jitLaunchScriptJs = appToReplace.appInfo.jitLaunchScriptJs
             finalNewApp.altSource = appToReplace.appInfo.altSource
             finalNewApp.altSourceIdentifier = appToReplace.appInfo.altSourceIdentifier
+            finalNewApp.enableUpdates = appToReplace.appInfo.enableUpdates
             finalNewApp.autoSaveDisabled = false
             finalNewApp.save()
         } else {
             // enable SDK version spoof by defalut
             finalNewApp.spoofSDKVersion = true
+            finalNewApp.enableUpdates = false
         }
         finalNewApp.installationDate = Date.now
         if let altSource = altSource {
             finalNewApp.altSource = altSource.name
             finalNewApp.altSourceIdentifier = altSource.identifier ?? altSourceURL?.absoluteString
+            if appToReplace == nil {
+                finalNewApp.enableUpdates = true
+            }
         }
         
         DispatchQueue.main.async {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -431,7 +431,8 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.InstallAppNotification)) { obj in
             if let obj2 = obj.object as? [String: Any], let installUrl = obj2["url"] as? URL {
                 let source = obj2["source"] as? AltStoreSource
-                Task { await installFromUrl(urlStr: installUrl.absoluteString, altSource: source) }
+                let sourceURL = obj2["sourceURL"] as? URL
+                Task { await installFromUrl(urlStr: installUrl.absoluteString, altSource: source, altSourceURL: sourceURL) }
             }
         }
         .apply {
@@ -584,7 +585,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     func startInstallApp(_ fileUrl:URL) async {
         do {
             self.installprogressVisible = true
-            try await installIpaFile(fileUrl, altSource: nil)
+            try await installIpaFile(fileUrl, altSource: nil, altSourceURL: nil)
             try FileManager.default.removeItem(at: fileUrl)
         } catch {
             errorInfo = error.localizedDescription
@@ -597,7 +598,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         extract(path, destination, progress)
     }
     
-    func installIpaFile(_ url:URL, altSource: AltStoreSource?) async throws {
+    func installIpaFile(_ url:URL, altSource: AltStoreSource? = nil, altSourceURL: URL? = nil) async throws {
         let fm = FileManager()
         
         let installProgress = Progress.discreteProgress(totalUnitCount: 100)
@@ -752,8 +753,8 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             finalNewApp.fixLocalNotification = appToReplace.appInfo.fixLocalNotification
             finalNewApp.lastLaunched = appToReplace.appInfo.lastLaunched
             finalNewApp.jitLaunchScriptJs = appToReplace.appInfo.jitLaunchScriptJs
-            finalNewApp.remark = appToReplace.appInfo.remark
             finalNewApp.altSource = appToReplace.appInfo.altSource
+            finalNewApp.altSourceIdentifier = appToReplace.appInfo.altSourceIdentifier
             finalNewApp.autoSaveDisabled = false
             finalNewApp.save()
         } else {
@@ -763,6 +764,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         finalNewApp.installationDate = Date.now
         if let altSource = altSource {
             finalNewApp.altSource = altSource.name
+            finalNewApp.altSourceIdentifier = altSource.identifier ?? altSourceURL?.absoluteString
         }
         
         DispatchQueue.main.async {
@@ -803,7 +805,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         await installFromUrl(urlStr: installUrlStr)
     }
     
-    func installFromPlist(urlStr: String) async {
+    func installFromPlist(urlStr: String, altSource: AltStoreSource? = nil, altSourceURL: URL? = nil) async {
         if self.installprogressVisible {
             return
         }
@@ -861,7 +863,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 return
             }
             
-            await installFromUrl(urlStr: ipaUrlStr)
+            await installFromUrl(urlStr: ipaUrlStr, altSource: altSource, altSourceURL: altSourceURL)
             
         } catch {
             errorInfo = error.localizedDescription
@@ -869,7 +871,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         }
     }
     
-    func installFromUrl(urlStr: String, altSource: AltStoreSource? = nil) async {
+    func installFromUrl(urlStr: String, altSource: AltStoreSource? = nil, altSourceURL: URL? = nil) async {
         // ignore any install request if we are installing another app
         if self.installprogressVisible {
             return
@@ -912,7 +914,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             }
             
             do {
-                try await installIpaFile(installUrl, altSource: altSource)
+                try await installIpaFile(installUrl, altSource: altSource, altSourceURL: altSourceURL)
             } catch {
                 errorInfo = error.localizedDescription
                 errorShow = true
@@ -948,7 +950,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             if downloadHelper.cancelled {
                 return
             }
-            try await installIpaFile(destinationURL, altSource: altSource)
+            try await installIpaFile(destinationURL, altSource: altSource, altSourceURL: altSourceURL)
             try fileManager.removeItem(at: destinationURL)
         } catch {
             errorInfo = error.localizedDescription

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -430,7 +430,8 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.InstallAppNotification)) { obj in
             if let obj2 = obj.object as? [String: Any], let installUrl = obj2["url"] as? URL {
-                Task { await installFromUrl(urlStr: installUrl.absoluteString) }
+                let source = obj2["source"] as? AltStoreSource
+                Task { await installFromUrl(urlStr: installUrl.absoluteString, altSource: source) }
             }
         }
         .apply {
@@ -583,7 +584,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     func startInstallApp(_ fileUrl:URL) async {
         do {
             self.installprogressVisible = true
-            try await installIpaFile(fileUrl)
+            try await installIpaFile(fileUrl, altSource: nil)
             try FileManager.default.removeItem(at: fileUrl)
         } catch {
             errorInfo = error.localizedDescription
@@ -596,7 +597,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         extract(path, destination, progress)
     }
     
-    func installIpaFile(_ url:URL) async throws {
+    func installIpaFile(_ url:URL, altSource: AltStoreSource?) async throws {
         let fm = FileManager()
         
         let installProgress = Progress.discreteProgress(totalUnitCount: 100)
@@ -751,6 +752,8 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             finalNewApp.fixLocalNotification = appToReplace.appInfo.fixLocalNotification
             finalNewApp.lastLaunched = appToReplace.appInfo.lastLaunched
             finalNewApp.jitLaunchScriptJs = appToReplace.appInfo.jitLaunchScriptJs
+            finalNewApp.remark = appToReplace.appInfo.remark
+            finalNewApp.altSource = appToReplace.appInfo.altSource
             finalNewApp.autoSaveDisabled = false
             finalNewApp.save()
         } else {
@@ -758,6 +761,9 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             finalNewApp.spoofSDKVersion = true
         }
         finalNewApp.installationDate = Date.now
+        if let altSource = altSource {
+            finalNewApp.altSource = altSource.name
+        }
         
         DispatchQueue.main.async {
             if let appToReplace {
@@ -863,7 +869,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         }
     }
     
-    func installFromUrl(urlStr: String) async {
+    func installFromUrl(urlStr: String, altSource: AltStoreSource? = nil) async {
         // ignore any install request if we are installing another app
         if self.installprogressVisible {
             return
@@ -906,7 +912,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             }
             
             do {
-                try await installIpaFile(installUrl)
+                try await installIpaFile(installUrl, altSource: altSource)
             } catch {
                 errorInfo = error.localizedDescription
                 errorShow = true
@@ -942,7 +948,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             if downloadHelper.cancelled {
                 return
             }
-            try await installIpaFile(destinationURL)
+            try await installIpaFile(destinationURL, altSource: altSource)
             try fileManager.removeItem(at: destinationURL)
         } catch {
             errorInfo = error.localizedDescription

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -753,9 +753,16 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             finalNewApp.fixLocalNotification = appToReplace.appInfo.fixLocalNotification
             finalNewApp.lastLaunched = appToReplace.appInfo.lastLaunched
             finalNewApp.jitLaunchScriptJs = appToReplace.appInfo.jitLaunchScriptJs
-            finalNewApp.altSource = appToReplace.appInfo.altSource
-            finalNewApp.altSourceIdentifier = appToReplace.appInfo.altSourceIdentifier
-            finalNewApp.enableUpdates = appToReplace.appInfo.enableUpdates
+            if let altSource = altSource {
+                finalNewApp.altSource = altSource.name
+                finalNewApp.altSourceIdentifier = altSource.identifier ?? altSourceURL?.absoluteString
+                finalNewApp.enableUpdates = appToReplace.appInfo.enableUpdates
+            } else {
+                // IPA install, strip AltSource data
+                finalNewApp.altSource = nil
+                finalNewApp.altSourceIdentifier = nil
+                finalNewApp.enableUpdates = false
+            }
             finalNewApp.autoSaveDisabled = false
             finalNewApp.save()
         } else {

--- a/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
+++ b/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
@@ -616,6 +616,7 @@ struct LCSourcesView: View {
         }
         .onAppear {
             expandedSources = []
+            updateTotalUpdateableCount()
             if !isViewAppeared {
                 guard sharedModel.selectedTab == .sources, let link = sharedModel.deepLink else { return }
                 sharedModel.deepLink = nil
@@ -626,11 +627,18 @@ struct LCSourcesView: View {
         .onChange(of: viewModel.sources) { newSources in
             let newSet = Set(newSources.map { $0.id })
             expandedSources = expandedSources.intersection(newSet)
+            updateTotalUpdateableCount()
         }
         .onChange(of: sharedModel.deepLink) { link in
             guard sharedModel.selectedTab == .sources, let link else { return }
             sharedModel.deepLink = nil
             handleURL(url: link)
+        }
+        .onChange(of: sharedModel.apps) { _ in
+            updateTotalUpdateableCount()
+        }
+        .onChange(of: sharedModel.hiddenApps) { _ in
+            updateTotalUpdateableCount()
         }
     }
     
@@ -704,6 +712,44 @@ struct LCSourcesView: View {
                 expandedSources.insert(id)
             }
         }
+    }
+    
+    private func updateTotalUpdateableCount() {
+        var total = 0
+        for item in viewModel.sources {
+            guard let source = item.source else { continue }
+            let sourceIds = [source.identifier, item.url.absoluteString].compactMap { $0 }
+            let hasDuplicates = Dictionary(grouping: source.apps, by: \.bundleIdentifier).contains { $1.count > 1 }
+            guard !hasDuplicates else { continue }
+            
+            for app in source.apps {
+                guard let installed = (sharedModel.apps + sharedModel.hiddenApps).first(where: { $0.appInfo.bundleIdentifier() == app.bundleIdentifier && sourceIds.contains($0.appInfo.altSourceIdentifier ?? "") }) else {
+                    continue
+                }
+                guard installed.appInfo.enableUpdates, let latestVersion = app.latestVersion?.version else { continue }
+                if let installedVersion = installed.appInfo.version() {
+                    if compareVersions(installedVersion, latestVersion) < 0 {
+                        total += 1
+                    }
+                }
+            }
+        }
+        sharedModel.totalUpdateableAppsCount = total
+    }
+    
+    private func compareVersions(_ installed: String, _ available: String) -> Int {
+        let installedParts = installed.split(separator: ".").compactMap { Int($0) }
+        let availableParts = available.split(separator: ".").compactMap { Int($0) }
+        
+        let maxLength = max(installedParts.count, availableParts.count)
+        for i in 0..<maxLength {
+            let installedPart = i < installedParts.count ? installedParts[i] : 0
+            let availablePart = i < availableParts.count ? availableParts[i] : 0
+            
+            if availablePart > installedPart { return 1 }
+            if availablePart < installedPart { return -1 }
+        }
+        return 0
     }
     
     func handleURL(url : URL) {
@@ -865,9 +911,49 @@ private struct AltStoreSourceSectionView: View {
     let onRemove: () -> Void
     let toggleExpanded: () -> Void
     
+    @EnvironmentObject private var sharedModel: SharedModel
+    
+    private var sourceIdentifiers: [String] {
+        var ids: [String] = []
+        if let identifier = item.source?.identifier {
+            ids.append(identifier)
+        }
+        ids.append(item.url.absoluteString)
+        return ids
+    }
+    
     private var hasDuplicateBundleIDs: Bool {
         Dictionary(grouping: item.source?.apps ?? [], by: \.bundleIdentifier)
             .contains { $1.count > 1 }
+    }
+    
+    private var updateableAppCount: Int {
+        guard !hasDuplicateBundleIDs, let source = item.source else { return 0 }
+        return source.apps.filter { app in
+            guard let installedApp = (sharedModel.apps + sharedModel.hiddenApps).first(where: { $0.appInfo.bundleIdentifier() == app.bundleIdentifier && sourceIdentifiers.contains($0.appInfo.altSourceIdentifier ?? "") }) else {
+                return false
+            }
+            guard installedApp.appInfo.enableUpdates, let latestVersion = app.latestVersion?.version else { return false }
+            if let installedVersion = installedApp.appInfo.version() {
+                return compareVersions(installedVersion, latestVersion) < 0
+            }
+            return false
+        }.count
+    }
+    
+    private func compareVersions(_ installed: String, _ available: String) -> Int {
+        let installedParts = installed.split(separator: ".").compactMap { Int($0) }
+        let availableParts = available.split(separator: ".").compactMap { Int($0) }
+        
+        let maxLength = max(installedParts.count, availableParts.count)
+        for i in 0..<maxLength {
+            let installedPart = i < installedParts.count ? installedParts[i] : 0
+            let availablePart = i < availableParts.count ? availableParts[i] : 0
+            
+            if availablePart > installedPart { return 1 }
+            if availablePart < installedPart { return -1 }
+        }
+        return 0
     }
 
     var body: some View {
@@ -893,14 +979,25 @@ private struct AltStoreSourceSectionView: View {
                         Button("lc.sources.refresh".loc, systemImage: "arrow.clockwise", action: onRefresh)
                         Button("lc.sources.removeSource".loc, systemImage: "trash", role: .destructive, action: onRemove)
                         if hasDuplicateBundleIDs {
-                            Text("Non-standard AltSource detected - updates not supported")
+                            Text("lc.sources.error.nonStandardAltSource".loc)
                                 .font(.footnote)
                                 .foregroundColor(.secondary)
                         }
                     } label: {
-                        Image(systemName: "ellipsis.circle")
-                            .imageScale(.large)
-                            .foregroundColor(.secondary)
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "ellipsis.circle")
+                                .imageScale(.large)
+                                .foregroundColor(.secondary)
+                            
+                            if updateableAppCount > 0 {
+                                Text(String(updateableAppCount))
+                                    .font(.system(size: 10, weight: .bold))
+                                    .foregroundColor(.white)
+                                    .frame(width: 16, height: 16)
+                                    .background(Circle().fill(Color.red))
+                                    .offset(x: 6, y: -6)
+                            }
+                        }
                     }
                 }
             }
@@ -980,6 +1077,38 @@ private struct LCSourceAppBanner: View {
             .contains { $1.count > 1 }
     }
     
+    private var installedApp: LCAppModel? {
+        (sharedModel.apps + sharedModel.hiddenApps).first { installedApp in
+            installedApp.appInfo.bundleIdentifier() == app.bundleIdentifier &&
+            (installedApp.appInfo.altSourceIdentifier != nil && sourceIdentifiers.contains(installedApp.appInfo.altSourceIdentifier))
+        }
+    }
+    
+    private func compareVersions(_ installed: String, _ available: String) -> Int {
+        let installedParts = installed.split(separator: ".").compactMap { Int($0) }
+        let availableParts = available.split(separator: ".").compactMap { Int($0) }
+        
+        let maxLength = max(installedParts.count, availableParts.count)
+        for i in 0..<maxLength {
+            let installedPart = i < installedParts.count ? installedParts[i] : 0
+            let availablePart = i < availableParts.count ? availableParts[i] : 0
+            
+            if availablePart > installedPart { return 1 }
+            if availablePart < installedPart { return -1 }
+        }
+        return 0
+    }
+    
+    private var hasUpdate: Bool {
+        guard !hasDuplicateBundleIDs, let installed = installedApp else { return false }
+        guard installed.appInfo.enableUpdates, let latestVersion = app.latestVersion?.version else { return false }
+        
+        if let installedVersion = installed.appInfo.version() {
+            return compareVersions(installedVersion, latestVersion) < 0
+        }
+        return false
+    }
+    
     private var canReinstall: Bool {
         guard !hasDuplicateBundleIDs else { return false }
         return (sharedModel.apps + sharedModel.hiddenApps).contains { installedApp in
@@ -992,7 +1121,10 @@ private struct LCSourceAppBanner: View {
     }
     
     private var actionTitle: String {
-        canReinstall ? "lc.common.reinstall".loc : "lc.common.install".loc
+        if hasUpdate {
+            return "lc.sources.update".loc
+        }
+        return canReinstall ? "lc.common.reinstall".loc : "lc.common.install".loc
     }
     
     @AppStorage("dynamicColors") private var dynamicColors = true
@@ -1036,9 +1168,18 @@ private struct LCSourceAppBanner: View {
     var body: some View {
         HStack {
             HStack(alignment: .center, spacing: 12) {
-                SourceIconView(url: app.iconURL)
-                    .frame(width: 60, height: 60)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                ZStack(alignment: .topTrailing) {
+                    SourceIconView(url: app.iconURL)
+                        .frame(width: 60, height: 60)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    
+                    if hasUpdate && app.latestVersion != nil {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 16, height: 16)
+                            .offset(x: 2, y: -2)
+                    }
+                }
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
                         Text(app.name)

--- a/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
+++ b/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
@@ -517,7 +517,7 @@ struct LCSourcesView: View {
                                     isFiltering: isFiltering,
                                     isExpanded: expandedSources.contains(item.id),
                                     onRefresh: { Task { await viewModel.refreshSource(item) } },
-                                    onInstall: install(app:),
+                                    onInstall: { app in install(app: app, source: item.source!) },
                                     onRemove: { sourcePendingRemoval = item },
                                     toggleExpanded: { toggleExpansion(for: item.id) }
                                 )
@@ -681,7 +681,7 @@ struct LCSourcesView: View {
     }
     
     @MainActor
-    private func install(app: AltStoreSourceApp) {
+    private func install(app: AltStoreSourceApp, source: AltStoreSource) {
         guard let downloadURL = app.latestVersion?.downloadURL else {
             errorMessage = "lc.sources.error.missingDownload".loc
             return
@@ -690,7 +690,7 @@ struct LCSourcesView: View {
             DataManager.shared.model.selectedTab = .apps
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            NotificationCenter.default.post(name: NSNotification.InstallAppNotification, object: ["url": downloadURL])
+            NotificationCenter.default.post(name: NSNotification.InstallAppNotification, object: ["url": downloadURL, "source": source])
         }
 
 

--- a/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
+++ b/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
@@ -517,7 +517,7 @@ struct LCSourcesView: View {
                                     isFiltering: isFiltering,
                                     isExpanded: expandedSources.contains(item.id),
                                     onRefresh: { Task { await viewModel.refreshSource(item) } },
-                                    onInstall: { app in install(app: app, source: item.source!) },
+                                    onInstall: { app in install(app: app, source: item.source!, sourceUrl: item.url) },
                                     onRemove: { sourcePendingRemoval = item },
                                     toggleExpanded: { toggleExpansion(for: item.id) }
                                 )
@@ -681,7 +681,7 @@ struct LCSourcesView: View {
     }
     
     @MainActor
-    private func install(app: AltStoreSourceApp, source: AltStoreSource) {
+    private func install(app: AltStoreSourceApp, source: AltStoreSource, sourceUrl: URL) {
         guard let downloadURL = app.latestVersion?.downloadURL else {
             errorMessage = "lc.sources.error.missingDownload".loc
             return
@@ -690,7 +690,7 @@ struct LCSourcesView: View {
             DataManager.shared.model.selectedTab = .apps
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            NotificationCenter.default.post(name: NSNotification.InstallAppNotification, object: ["url": downloadURL, "source": source])
+            NotificationCenter.default.post(name: NSNotification.InstallAppNotification, object: ["url": downloadURL, "source": source, "sourceURL": sourceUrl])
         }
 
 
@@ -865,6 +865,11 @@ private struct AltStoreSourceSectionView: View {
     let onRemove: () -> Void
     let toggleExpanded: () -> Void
     
+    private var hasDuplicateBundleIDs: Bool {
+        Dictionary(grouping: item.source?.apps ?? [], by: \.bundleIdentifier)
+            .contains { $1.count > 1 }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .center, spacing: 12) {
@@ -887,6 +892,11 @@ private struct AltStoreSourceSectionView: View {
                     Menu {
                         Button("lc.sources.refresh".loc, systemImage: "arrow.clockwise", action: onRefresh)
                         Button("lc.sources.removeSource".loc, systemImage: "trash", role: .destructive, action: onRemove)
+                        if hasDuplicateBundleIDs {
+                            Text("Non-standard AltSource detected - updates not supported")
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                        }
                     } label: {
                         Image(systemName: "ellipsis.circle")
                             .imageScale(.large)
@@ -894,7 +904,7 @@ private struct AltStoreSourceSectionView: View {
                     }
                 }
             }
-            
+
             if let subtitle = item.source?.subtitle, !subtitle.isEmpty {
                 Text(subtitle)
                     .font(.footnote)
@@ -904,7 +914,7 @@ private struct AltStoreSourceSectionView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
-            
+
             if let error = item.error {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("lc.sources.section.error".loc)
@@ -924,7 +934,7 @@ private struct AltStoreSourceSectionView: View {
             } else if let source = item.source, isExpanded || isFiltering {
                 VStack(spacing: 12) {
                     ForEach(filteredApps[0..<min(50, filteredApps.count)]) { app in
-                        LCSourceAppBanner(app: app, source: source, installAction: onInstall)
+                        LCSourceAppBanner(app: app, source: source, sourceUrl: item.url, installAction: onInstall)
                     }
                     if filteredApps.isEmpty {
                         if source.apps.isEmpty || isFiltering {
@@ -951,7 +961,39 @@ private struct AltStoreSourceSectionView: View {
 private struct LCSourceAppBanner: View {
     let app: AltStoreSourceApp
     let source: AltStoreSource
+    let sourceUrl: URL
     let installAction: (AltStoreSourceApp) -> Void
+    
+    @EnvironmentObject private var sharedModel: SharedModel
+    
+    private var sourceIdentifiers: [String] {
+        var ids: [String] = []
+        if let identifier = source.identifier {
+            ids.append(identifier)
+        }
+        ids.append(sourceUrl.absoluteString)
+        return ids
+    }
+    
+    private var hasDuplicateBundleIDs: Bool {
+        Dictionary(grouping: source.apps, by: \.bundleIdentifier)
+            .contains { $1.count > 1 }
+    }
+    
+    private var canReinstall: Bool {
+        guard !hasDuplicateBundleIDs else { return false }
+        return (sharedModel.apps + sharedModel.hiddenApps).contains { installedApp in
+            guard installedApp.appInfo.bundleIdentifier() == app.bundleIdentifier,
+                  let installedAltSource = installedApp.appInfo.altSourceIdentifier else {
+                return false
+            }
+            return sourceIdentifiers.contains(installedAltSource)
+        }
+    }
+    
+    private var actionTitle: String {
+        canReinstall ? "lc.common.reinstall".loc : "lc.common.install".loc
+    }
     
     @AppStorage("dynamicColors") private var dynamicColors = true
     @Environment(\.colorScheme) var colorScheme
@@ -1027,7 +1069,7 @@ private struct LCSourceAppBanner: View {
             Button {
                 installAction(app)
             } label: {
-                Text("lc.common.install".loc)
+                Text(actionTitle)
                     .bold()
                     .foregroundColor(.white)
                     .lineLimit(1)

--- a/LiveContainerSwiftUI/Views/LCTabView.swift
+++ b/LiveContainerSwiftUI/Views/LCTabView.swift
@@ -65,6 +65,7 @@ struct LCTabView: View {
                             .tabItem {
                                 Label("lc.tabView.sources".loc, systemImage: "books.vertical")
                             }
+                            .badge(sharedModel.totalUpdateableAppsCount > 0 ? String(sharedModel.totalUpdateableAppsCount) : nil)
                             .tag(LCTabIdentifier.sources)
                     }
                     appListView

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -10159,90 +10159,6 @@
         }
       }
     },
-    "lc.common.reinstall" : {
-      "comment" : "lc.common.reinstall",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إعادة التثبيت"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neu installieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reinstall"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinstaller"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reinstalla"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再インストール"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "재설치"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zainstaluj ponownie"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reinstalar"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переустановить"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yeniden yükle"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt lại"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新安装"
-          }
-        }
-      }
-    },
     "lc.common.language" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -28111,6 +28027,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "執行程式"
+          }
+        }
+      }
+    },
+    "lc.appSettings.enableUpdates" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Updates"
+          }
+        }
+      }
+    },
+    "lc.common.reinstall" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstall"
+          }
+        }
+      }
+    },
+    "lc.sources.update" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update"
+          }
+        }
+      }
+    },
+    "lc.sources.error.nonStandardAltSource" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non-standard AltSource detected - updates not supported"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -10159,6 +10159,90 @@
         }
       }
     },
+    "lc.common.reinstall" : {
+      "comment" : "lc.common.reinstall",
+      "extractionState" : "stale",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إعادة التثبيت"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neu installieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstall"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinstaller"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstalla"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再インストール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "재설치"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zainstaluj ponownie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reinstalar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переустановить"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yeniden yükle"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cài đặt lại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新安装"
+          }
+        }
+      }
+    },
     "lc.common.language" : {
       "extractionState" : "manual",
       "localizations" : {


### PR DESCRIPTION
When an update to an app exists in an AltSource (that is, an App ID that is installed exists in AltSource apps, and the app version differs between AltSource and installed version), the Run button splits into two buttons (a Run button and an Update button), and clicking on this will download and install the app version on AltSource (this is the same thing that happens when you click the "Install" button in the AltSource tab). Fixes #1018:

![IMG_0366](https://github.com/user-attachments/assets/f538f6ea-7ad8-4c25-89dd-06b1717e2ebd)
