### PR TITLE
Fix WebKit Media playing in Multitasking mode

### DIFF
--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 				Notification.m,
 				TweakLoader.m,
 				"UIKit+GuestHooks.m",
+				"WebKit+GuestHooks.m",
 				utils.m,
 			);
 			target = 174140392D9C0D0000F3F928 /* TweakLoader */;

--- a/TweakLoader/WebKit+GuestHooks.m
+++ b/TweakLoader/WebKit+GuestHooks.m
@@ -1,0 +1,85 @@
+@import WebKit;
+#import "utils.h"
+
+// ============================================================
+// WebKit media playback fix for extension-hosted guest apps.
+//
+// Fixes: video in WKWebView stalls after the first decoded frame
+// when a guest app runs in multitasking mode on iOS 17.4 or later.
+//
+// Root cause:
+//   Starting in iOS 17.4, WKPreferences added a new embedder-level
+//   preference `MediaCapabilityGrantsEnabled` which defaults to YES
+//   on real device WebKit builds (Source/WTF/Scripts/Preferences/
+//   UnifiedWebPreferences.yaml, condition ENABLE(EXTENSION_CAPABILITIES)).
+//
+//   When enabled, WebKit assumes that BrowserEngineKit media
+//   capability grants will manage media lifecycle, and takes
+//   shortcut branches that SILENTLY SKIP:
+//     - registering the presenting application PID with
+//       mediaservicesd (GPUConnectionToWebProcess::
+//       providePresentingApplicationPID, RemoteAudioSessionProxyManager)
+//     - taking the MediaPlayback process assertion for the
+//       playing page (WebProcessProxy::updateAudibleMediaAssertion)
+//
+//   LiveContainer hosts guest apps via NSExtension. In that
+//   context, BrowserEngineKit capability grants do not propagate
+//   the way the non-extension path assumes, so neither the
+//   presenting-PID registration nor the MediaPlayback assertion
+//   ever happens. WebKit's GPU process decodes the initial
+//   pre-roll frame, then the playback clock is never advanced
+//   and the pipeline stalls silently (no errors, video element
+//   reports paused=false readyState=4 but currentTime=0).
+//
+// Fix:
+//   On every new WKWebView, clear _mediaCapabilityGrantsEnabled
+//   before init. That sends WebKit down the pre-17.4 code path,
+//   which always registers the presenting PID and takes the
+//   MediaPlayback assertion — the path that has been working
+//   in extensions all along.
+//
+// References:
+//   Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+//     _mediaCapabilityGrantsEnabled property, ios(17.4)+
+//   Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+//     lines 183-186 and 273-276 (silent-skip blocks)
+//   Source/WebKit/UIProcess/WebProcessProxy.cpp
+//     lines 1936-1963 (skipped MediaPlayback assertion)
+//   Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+//     lines 716-727 (silent-skip providePresentingApplicationPID)
+// ============================================================
+
+@interface WKPreferences (LCMediaCapabilityFix)
+- (void)_setMediaCapabilityGrantsEnabled:(BOOL)enabled;
+@end
+
+@interface WKWebView (LCMediaCapabilityFix)
+- (instancetype)hook_initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration;
+@end
+
+@implementation WKWebView (LCMediaCapabilityFix)
+
+- (instancetype)hook_initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration {
+    if (configuration) {
+        WKPreferences *prefs = configuration.preferences;
+        if ([prefs respondsToSelector:@selector(_setMediaCapabilityGrantsEnabled:)]) {
+            // Disable the iOS 17.4+ capability-grant shortcut so WebKit
+            // takes the pre-17.4 path that actually registers the
+            // presenting app PID and takes the MediaPlayback assertion.
+            [prefs _setMediaCapabilityGrantsEnabled:NO];
+        }
+    }
+    return [self hook_initWithFrame:frame configuration:configuration];
+}
+
+@end
+
+__attribute__((constructor))
+static void WebKitGuestHooksInit(void) {
+    if (!NSUserDefaults.lcGuestAppId) return;
+    if (@available(iOS 17.4, *)) {
+        swizzle(WKWebView.class,
+                @selector(initWithFrame:configuration:),
+                @selector(hook_initWithFrame:configuration:));
+    }
+}

--- a/TweakLoader/WebKit+GuestHooks.m
+++ b/TweakLoader/WebKit+GuestHooks.m
@@ -32,11 +32,22 @@
 //   reports paused=false readyState=4 but currentTime=0).
 //
 // Fix:
-//   On every new WKWebView, clear _mediaCapabilityGrantsEnabled
-//   before init. That sends WebKit down the pre-17.4 code path,
-//   which always registers the presenting PID and takes the
-//   MediaPlayback assertion — the path that has been working
-//   in extensions all along.
+//   Clear _mediaCapabilityGrantsEnabled before any WKWebView is
+//   bound to a WebContent process. That sends WebKit down the
+//   pre-17.4 code path, which always registers the presenting
+//   PID and takes the MediaPlayback assertion — the path that
+//   has been working in extensions all along.
+//
+//   We hook three points so the fix takes effect even if a
+//   WKWebView is created very early (before this constructor
+//   runs) or if a WKWebViewConfiguration is built without going
+//   through WKWebView init:
+//     1. WKWebViewConfiguration init   (catches early configs)
+//     2. WKWebView initWithFrame:configuration: (covers the
+//        common path and any config not built via plain init)
+//     3. On load, walk live windows and patch any existing
+//        WKWebView's preferences (recovers if the constructor
+//        ran after Firefox already created its first WKWebView)
 //
 // References:
 //   Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -53,6 +64,12 @@
 - (void)_setMediaCapabilityGrantsEnabled:(BOOL)enabled;
 @end
 
+static void disableMediaCapabilityGrantsOnPrefs(WKPreferences *prefs) {
+    if ([prefs respondsToSelector:@selector(_setMediaCapabilityGrantsEnabled:)]) {
+        [prefs _setMediaCapabilityGrantsEnabled:NO];
+    }
+}
+
 @interface WKWebView (LCMediaCapabilityFix)
 - (instancetype)hook_initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration;
 @end
@@ -61,25 +78,66 @@
 
 - (instancetype)hook_initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration {
     if (configuration) {
-        WKPreferences *prefs = configuration.preferences;
-        if ([prefs respondsToSelector:@selector(_setMediaCapabilityGrantsEnabled:)]) {
-            // Disable the iOS 17.4+ capability-grant shortcut so WebKit
-            // takes the pre-17.4 path that actually registers the
-            // presenting app PID and takes the MediaPlayback assertion.
-            [prefs _setMediaCapabilityGrantsEnabled:NO];
-        }
+        disableMediaCapabilityGrantsOnPrefs(configuration.preferences);
     }
     return [self hook_initWithFrame:frame configuration:configuration];
 }
 
 @end
 
+@interface WKWebViewConfiguration (LCMediaCapabilityFix)
+- (instancetype)hook_init;
+@end
+
+@implementation WKWebViewConfiguration (LCMediaCapabilityFix)
+
+- (instancetype)hook_init {
+    WKWebViewConfiguration *cfg = [self hook_init];
+    if (cfg) {
+        disableMediaCapabilityGrantsOnPrefs(cfg.preferences);
+    }
+    return cfg;
+}
+
+@end
+
+static void patchWebViewsInView(UIView *view) {
+    if ([view isKindOfClass:[WKWebView class]]) {
+        disableMediaCapabilityGrantsOnPrefs(((WKWebView *)view).configuration.preferences);
+    }
+    for (UIView *sub in view.subviews) {
+        patchWebViewsInView(sub);
+    }
+}
+
+static void patchExistingWebViews(void) {
+    UIApplication *app = [UIApplication sharedApplication];
+    if (!app) return;
+    for (UIScene *scene in app.connectedScenes) {
+        if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+        for (UIWindow *window in ((UIWindowScene *)scene).windows) {
+            patchWebViewsInView(window);
+        }
+    }
+}
+
 __attribute__((constructor))
 static void WebKitGuestHooksInit(void) {
     if (!NSUserDefaults.lcGuestAppId) return;
     if (@available(iOS 17.4, *)) {
+        swizzle(WKWebViewConfiguration.class,
+                @selector(init),
+                @selector(hook_init));
         swizzle(WKWebView.class,
                 @selector(initWithFrame:configuration:),
                 @selector(hook_initWithFrame:configuration:));
+
+        // If our constructor ran after the host already created its
+        // first WKWebView (e.g. during state restoration), patch live
+        // ones now so they pick up the corrected preference before
+        // their next media load.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            patchExistingWebViews();
+        });
     }
 }


### PR DESCRIPTION
This is AI generated code. It is a PoC that may not be merged in its current state, but it provides helpful insights and fixes #870

After hours of prompting, Claude succesfully identified the error and provided a fix.

### Problem

Video (and audio) fails to play in WebKit-based guest apps when running in LiveContainer's multitasking mode. The video element reports `paused:false, readyState:4`, a single pre-roll frame is decoded, but `currentTime` never advances and no error is raised. Regressed silently on iOS 17.4 - worked fine on 16.x (and possibly 17.0–17.3)

### Root cause

iOS 17.4 added the WKPreferences flag `_mediaCapabilityGrantsEnabled`, which defaults to **YES** on real-device WebKit. When enabled, WebKit assumes BrowserEngineKit media capability grants manage media lifecycle and takes shortcut branches that **silently  skip**:
 - Registering the presenting application PID with `mediaservicesd` (`GPUConnectionToWebProcess::providePresentingApplicationPID`, `RemoteAudioSessionProxyManager`)
 - Taking the MediaPlayback process assertion (`WebProcessProxy::updateAudibleMediaAssertion`)

In LiveContainer's NSExtension-hosted context, BrowserEngineKit capability grants don't propagate the way the non-extension code path assumes, so neither registration happens. The GPU process decodes the pre-roll frame, then the playback clock is never advanced and the pipeline stalls silently.

### Fix
Swizzle `-[WKWebView initWithFrame:configuration:]` in the guest process to call `_setMediaCapabilityGrantsEnabled:NO` on the passed-in `WKWebViewConfiguration`'s preferences. This makes WebKit take the pre-17.4 code path, which unconditionally registers the presenting app and takes the MediaPlayback assertion.

### Changes
- `TweakLoader/WebKit+GuestHooks.m` - new guest-side hook, gated by `@available(iOS 17.4, *)` and `NSUserDefaults.lcGuestAppId` so it   only runs in the guest process on affected OS versions.
- `LiveContainer.xcodeproj/project.pbxproj` - add the new file to the TweakLoader target.

### Proof

Source of truth - WebKit's preferences definition:

`Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml`, lines 4858–4872:
```
MediaCapabilityGrantsEnabled:
  type: bool
  status: embedder
  condition: ENABLE(EXTENSION_CAPABILITIES)
  humanReadableName: "Media Capability Grants"
  humanReadableDescription: "Enable granting and revoking of media capabilities"
  defaultValue:
    WebKitLegacy:
      default: false
    WebKit:
      "PLATFORM(IOS_FAMILY_SIMULATOR)": false
      default: true              # ← real-device iOS defaults to YES
    WebCore:
      "PLATFORM(IOS_FAMILY_SIMULATOR)": false
      default: true
```

API availability - `WKPreferencesPrivate.h`:
```
@property (nonatomic, setter=_setMediaCapabilityGrantsEnabled:) BOOL _mediaCapabilityGrantsEnabled 
WK_API_AVAILABLE(ios(17.4), visionos(1.1)) WK_API_UNAVAILABLE(macos);
```    
The property exists starting iOS 17.4, which matches the observation that "it stopped working in iOS 17/18."

The silent-skip gates triggered when true:

- `Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:720`:
```
void GPUConnectionToWebProcess::providePresentingApplicationPID(...) const {
    if (sharedPreferencesForWebProcessValue().mediaCapabilityGrantsEnabled)
        return;   // silently skip registering PID with mediaservicesd
    ...
}
```
- `Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:184, 274`: skips `updatePresentingProcesses` when enabled.
- `Source/WebKit/UIProcess/WebProcessProxy.cpp:1940-1948`: skips `ProcessAssertion::MediaPlayback` when enabled.