### PR TITLE
Add Safari extension bridge for guest app URL launches

### DIFF
--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		17CAE6262F230548008B1977 /* LiveContainerShared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1292BD62DCA3B660065E12D /* LiveContainerShared.framework */; };
 		17CAED2C2F234814008B1977 /* LaunchAppExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 17CAE6172F230449008B1977 /* LaunchAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		17E23DE92F443A9300C55733 /* LaunchAppExtensionHelper.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 17E23DDF2F443A9300C55733 /* LaunchAppExtensionHelper.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		19A100012F70000000A0B001 /* SafariWebExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 19A100042F70000000A0B001 /* SafariWebExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E11884B92EF7A164009C6FA6 /* dyld_bypass_validation.h in Headers */ = {isa = PBXBuildFile; fileRef = E11884B82EF7A15F009C6FA6 /* dyld_bypass_validation.h */; };
 		E1292AF32DCA3A660065E12D /* LiveProcess.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E1292AE52DCA3A660065E12D /* LiveProcess.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E1292BEC2DCA3B670065E12D /* LiveContainerShared.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E1292BD62DCA3B660065E12D /* LiveContainerShared.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -74,6 +75,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 17E23DDE2F443A9300C55733;
 			remoteInfo = LaunchAppExtensionHelper;
+		};
+		19A100022F70000000A0B001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17DCE9952C7067EC00731D42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 19A100062F70000000A0B001;
+			remoteInfo = SafariWebExtension;
 		};
 		E1292AF12DCA3A660065E12D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -135,6 +143,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
+				19A100012F70000000A0B001 /* SafariWebExtension.appex in Embed Foundation Extensions */,
 				17E23DE92F443A9300C55733 /* LaunchAppExtensionHelper.appex in Embed Foundation Extensions */,
 				17CAED2C2F234814008B1977 /* LaunchAppExtension.appex in Embed Foundation Extensions */,
 				E1292AF32DCA3A660065E12D /* LiveProcess.appex in Embed Foundation Extensions */,
@@ -166,6 +175,7 @@
 		17CAE6172F230449008B1977 /* LaunchAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = LaunchAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		17DCE99D2C7067EC00731D42 /* LiveContainer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LiveContainer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		17E23DDF2F443A9300C55733 /* LaunchAppExtensionHelper.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LaunchAppExtensionHelper.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		19A100042F70000000A0B001 /* SafariWebExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = SafariWebExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E11884B82EF7A15F009C6FA6 /* dyld_bypass_validation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = dyld_bypass_validation.h; sourceTree = "<group>"; };
 		E12928C92DCA38380065E12D /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		E1292AE52DCA3A660065E12D /* LiveProcess.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LiveProcess.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -228,6 +238,13 @@
 				Info.plist,
 			);
 			target = 17E23DDE2F443A9300C55733 /* LaunchAppExtensionHelper */;
+		};
+		19A1000D2F70000000A0B001 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 19A100062F70000000A0B001 /* SafariWebExtension */;
 		};
 		E1292AF72DCA3A660065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -323,6 +340,7 @@
 		17B0F8452DE16FE4008110EA /* xcconfigs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = xcconfigs; sourceTree = "<group>"; };
 		17CAE6182F230449008B1977 /* LaunchAppExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17CAE6252F230449008B1977 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LaunchAppExtension; sourceTree = "<group>"; };
 		17E23DE02F443A9300C55733 /* LaunchAppExtensionHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17E23DED2F443A9300C55733 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LaunchAppExtensionHelper; sourceTree = "<group>"; };
+		19A100052F70000000A0B001 /* SafariWebExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (19A1000D2F70000000A0B001 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SafariWebExtension; sourceTree = "<group>"; };
 		E1292AE72DCA3A660065E12D /* LiveProcess */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E1292AF72DCA3A660065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LiveProcess; sourceTree = "<group>"; };
 		E1292C1A2DCA48F00065E12D /* Tweaks */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E1292C202DCA48F00065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tweaks; sourceTree = "<group>"; };
 		E1292C242DCA4E6F0065E12D /* MultitaskSupport */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (E1292C2D2DCA4E800065E12D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, E1D5EDC02F48AA25004AF1E9 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = MultitaskSupport; sourceTree = "<group>"; };
@@ -383,6 +401,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		17E23DDC2F443A9300C55733 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		19A100082F70000000A0B001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -456,6 +481,7 @@
 				173545A92E2C7913001B3B4C /* SideStore */,
 				17CAE6182F230449008B1977 /* LaunchAppExtension */,
 				17E23DE02F443A9300C55733 /* LaunchAppExtensionHelper */,
+				19A100052F70000000A0B001 /* SafariWebExtension */,
 				174140B82D9C0F9100F3F928 /* Frameworks */,
 				17DCE99E2C7067EC00731D42 /* Products */,
 				17780D3B2E1C02420077E636 /* litehook */,
@@ -475,6 +501,7 @@
 				173545A82E2C7913001B3B4C /* SideStore.framework */,
 				17CAE6172F230449008B1977 /* LaunchAppExtension.appex */,
 				17E23DDF2F443A9300C55733 /* LaunchAppExtensionHelper.appex */,
+				19A100042F70000000A0B001 /* SafariWebExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -682,6 +709,7 @@
 				E1292BEA2DCA3B670065E12D /* PBXTargetDependency */,
 				173545AD2E2C7913001B3B4C /* PBXTargetDependency */,
 				17CAE61F2F230449008B1977 /* PBXTargetDependency */,
+				19A100032F70000000A0B001 /* PBXTargetDependency */,
 				17E23DE82F443A9300C55733 /* PBXTargetDependency */,
 			);
 			name = LiveContainer;
@@ -709,6 +737,28 @@
 			);
 			productName = LaunchAppExtensionHelper;
 			productReference = 17E23DDF2F443A9300C55733 /* LaunchAppExtensionHelper.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		19A100062F70000000A0B001 /* SafariWebExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 19A1000A2F70000000A0B001 /* Build configuration list for PBXNativeTarget "SafariWebExtension" */;
+			buildPhases = (
+				19A100072F70000000A0B001 /* Sources */,
+				19A100082F70000000A0B001 /* Frameworks */,
+				19A100092F70000000A0B001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				19A100052F70000000A0B001 /* SafariWebExtension */,
+			);
+			name = SafariWebExtension;
+			packageProductDependencies = (
+			);
+			productName = SafariWebExtension;
+			productReference = 19A100042F70000000A0B001 /* SafariWebExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 		E1292AE42DCA3A660065E12D /* LiveProcess */ = {
@@ -862,6 +912,7 @@
 				E1292BD52DCA3B660065E12D /* LiveContainerShared */,
 				173545A72E2C7913001B3B4C /* SideStore */,
 				17CAE6162F230449008B1977 /* LaunchAppExtension */,
+				19A100062F70000000A0B001 /* SafariWebExtension */,
 				17E23DDE2F443A9300C55733 /* LaunchAppExtensionHelper */,
 			);
 		};
@@ -897,6 +948,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		17E23DDD2F443A9300C55733 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		19A100092F70000000A0B001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -998,6 +1056,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		19A100072F70000000A0B001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E1292AE12DCA3A660065E12D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1050,6 +1115,11 @@
 			isa = PBXTargetDependency;
 			target = 17E23DDE2F443A9300C55733 /* LaunchAppExtensionHelper */;
 			targetProxy = 17E23DE72F443A9300C55733 /* PBXContainerItemProxy */;
+		};
+		19A100032F70000000A0B001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 19A100062F70000000A0B001 /* SafariWebExtension */;
+			targetProxy = 19A100022F70000000A0B001 /* PBXContainerItemProxy */;
 		};
 		E1292AF22DCA3A660065E12D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1733,6 +1803,87 @@
 			};
 			name = Release;
 		};
+		19A1000B2F70000000A0B001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 17B0F8452DE16FE4008110EA /* xcconfigs */;
+			baseConfigurationReferenceRelativePath = SafariWebExtension.xcconfig;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SafariWebExtension/SafariWebExtension.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SafariWebExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "LiveContainer Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		19A1000C2F70000000A0B001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 17B0F8452DE16FE4008110EA /* xcconfigs */;
+			baseConfigurationReferenceRelativePath = SafariWebExtension.xcconfig;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SafariWebExtension/SafariWebExtension.entitlements;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "$(DEVELOPMENT_TEAM)";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SafariWebExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "LiveContainer Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SafariServices,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "$(PRODUCT_BUNDLE_IDENTIFIER)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		E1292AF52DCA3A660065E12D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 17B0F8452DE16FE4008110EA /* xcconfigs */;
@@ -2029,6 +2180,15 @@
 			buildConfigurations = (
 				17E23DEB2F443A9300C55733 /* Debug */,
 				17E23DEC2F443A9300C55733 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		19A1000A2F70000000A0B001 /* Build configuration list for PBXNativeTarget "SafariWebExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				19A1000B2F70000000A0B001 /* Debug */,
+				19A1000C2F70000000A0B001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/LiveContainer.xcodeproj/xcshareddata/xcschemes/SafariWebExtension.xcscheme
+++ b/LiveContainer.xcodeproj/xcshareddata/xcschemes/SafariWebExtension.xcscheme
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "19A100062F70000000A0B001"
+               BuildableName = "SafariWebExtension.appex"
+               BlueprintName = "SafariWebExtension"
+               ReferencedContainer = "container:LiveContainer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "17DCE99C2C7067EC00731D42"
+               BuildableName = "LiveContainer.app"
+               BlueprintName = "LiveContainer"
+               ReferencedContainer = "container:LiveContainer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "17DCE99C2C7067EC00731D42"
+            BuildableName = "LiveContainer.app"
+            BlueprintName = "LiveContainer"
+            ReferencedContainer = "container:LiveContainer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "17DCE99C2C7067EC00731D42"
+            BuildableName = "LiveContainer.app"
+            BlueprintName = "LiveContainer"
+            ReferencedContainer = "container:LiveContainer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LiveContainer/LCBootstrap.m
+++ b/LiveContainer/LCBootstrap.m
@@ -32,6 +32,53 @@ bool isSharedBundle = false;
 bool isSideStore = false;
 bool sideStoreExist = false;
 
+static BOOL LCDispatchUniversalLink(NSURL *url) {
+    if (!url) {
+        return NO;
+    }
+
+    NSUserActivity *activity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+    activity.webpageURL = url;
+
+    UIApplication *application = [NSClassFromString(@"UIApplication") sharedApplication];
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in application.connectedScenes) {
+            id<UISceneDelegate> sceneDelegate = scene.delegate;
+            if ([sceneDelegate respondsToSelector:@selector(scene:continueUserActivity:)]) {
+                [sceneDelegate scene:scene continueUserActivity:activity];
+                return YES;
+            }
+        }
+    }
+
+    id<UIApplicationDelegate> appDelegate = application.delegate;
+    if ([appDelegate respondsToSelector:@selector(application:continueUserActivity:restorationHandler:)]) {
+        return [appDelegate application:application continueUserActivity:activity restorationHandler:^(__unused NSArray<id<UIUserActivityRestoring>> *restorableObjects) {}];
+    }
+
+    if (@available(iOS 13.0, *)) {
+        [application requestSceneSessionActivation:nil userActivity:activity options:nil errorHandler:nil];
+        return YES;
+    }
+
+    return NO;
+}
+
+static void LCDispatchLaunchURL(NSString *launchUrl) {
+    NSURL *url = [NSURL URLWithString:launchUrl];
+    if (!url) {
+        return;
+    }
+
+    NSString *scheme = url.scheme.lowercaseString;
+    if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
+        LCDispatchUniversalLink(url);
+        return;
+    }
+
+    [[NSClassFromString(@"UIApplication") sharedApplication] openURL:url options:@{} completionHandler:nil];
+}
+
 @implementation NSUserDefaults(LiveContainer)
 + (instancetype)lcUserDefaults {
     return lcUserDefaults;
@@ -614,9 +661,14 @@ int LiveContainerMain(int argc, char *argv[]) {
             if (secondsSinceDate < 0 && secondsSinceDate >= -3.0) {
                 selectedApp = selectedAppFromLaunchExtension;
                 selectedContainer = [lcSharedDefaults stringForKey:@"LCLaunchExtensionContainerName"];
+                NSString *launchUrl = [lcSharedDefaults stringForKey:@"LCLaunchExtensionOpenURL"];
+                if (launchUrl) {
+                    [lcUserDefaults setObject:launchUrl forKey:@"launchAppUrlScheme"];
+                }
             }
             [lcSharedDefaults removeObjectForKey:@"LCLaunchExtensionBundleID"];
             [lcSharedDefaults removeObjectForKey:@"LCLaunchExtensionContainerName"];
+            [lcSharedDefaults removeObjectForKey:@"LCLaunchExtensionOpenURL"];
         }
     }
     
@@ -710,9 +762,7 @@ int LiveContainerMain(int argc, char *argv[]) {
                     NSString *encodedUrl = [data base64EncodedStringWithOptions:0];
                     
                     NSString* finalUrl = [NSString stringWithFormat:@"%@://open-url?url=%@", runningLC, encodedUrl];
-                    NSURL* url = [NSURL URLWithString: finalUrl];
-                    
-                    [[NSClassFromString(@"UIApplication") sharedApplication] openURL:url options:@{} completionHandler:nil];
+                    LCDispatchLaunchURL(finalUrl);
 
                 }
             }
@@ -734,10 +784,15 @@ int LiveContainerMain(int argc, char *argv[]) {
                 NSData *data = [launchUrl dataUsingEncoding:NSUTF8StringEncoding];
                 NSString *encodedUrl = [data base64EncodedStringWithOptions:0];
                 
+                NSURL *url = [NSURL URLWithString:launchUrl];
+                NSString *scheme = url.scheme.lowercaseString;
+                if ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) {
+                    LCDispatchLaunchURL(launchUrl);
+                    return;
+                }
+
                 NSString* finalUrl = [NSString stringWithFormat:@"%@://open-url?url=%@", lcAppUrlScheme, encodedUrl];
-                NSURL* url = [NSURL URLWithString: finalUrl];
-                
-                [[NSClassFromString(@"UIApplication") sharedApplication] openURL:url options:@{} completionHandler:nil];
+                LCDispatchLaunchURL(finalUrl);
             });
         }
         NSSetUncaughtExceptionHandler(&exceptionHandler);

--- a/LiveContainerSwiftUI/App/LiveContainerSwiftUIApp.swift
+++ b/LiveContainerSwiftUI/App/LiveContainerSwiftUIApp.swift
@@ -20,8 +20,6 @@ struct LiveContainerSwiftUIApp : SwiftUI.App {
         
         var tempApps: [LCAppModel] = []
         var tempHiddenApps: [LCAppModel] = []
-        var tempURLSchemes: Set<String>? = DataManager.shared.model.multiLCStatus != 2 ? Set() : nil
-
         do {
             // load apps
             try fm.createDirectory(at: LCPath.bundlePath, withIntermediateDirectories: true)
@@ -37,7 +35,6 @@ struct LiveContainerSwiftUIApp : SwiftUI.App {
                     tempHiddenApps.append(LCAppModel(appInfo: newApp))
                 } else {
                     tempApps.append(LCAppModel(appInfo: newApp))
-                    tempURLSchemes?.formUnion(newApp.urlSchemes() as! [String])
                 }
             }
             if LCPath.lcGroupDocPath != LCPath.docPath {
@@ -54,7 +51,6 @@ struct LiveContainerSwiftUIApp : SwiftUI.App {
                         tempHiddenApps.append(LCAppModel(appInfo: newApp))
                     } else {
                         tempApps.append(LCAppModel(appInfo: newApp))
-                        tempURLSchemes?.formUnion(newApp.urlSchemes() as! [String])
                     }
                 }
             }
@@ -85,9 +81,7 @@ struct LiveContainerSwiftUIApp : SwiftUI.App {
         
         DataManager.shared.model.apps = tempApps
         DataManager.shared.model.hiddenApps = tempHiddenApps
-        if let tempURLSchemes {
-            UserDefaults.lcShared().set(Array(tempURLSchemes), forKey: "LCGuestURLSchemes")
-        }
+        DataManager.shared.model.syncSharedGuestURLIndex()
         
         _appDataFolderNames = State(initialValue: tempAppDataFolderNames)
         _tweakFolderNames = State(initialValue: tempTweakFolderNames)

--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -3,6 +3,7 @@ import Foundation
 protocol LCAppModelDelegate {
     func closeNavigationView()
     func changeAppVisibility(app : LCAppModel)
+    func appLaunchAvailabilityDidChange()
     func jitLaunch(appName: String) async
     func jitLaunch(withScript script: String, appName: String) async
     func jitLaunch(withPID pid: Int, withScript script: String?, appName: String) async
@@ -21,12 +22,18 @@ class LCAppModel: ObservableObject, Hashable {
     @Published var uiIsJITNeeded : Bool {
         didSet {
             appInfo.isJITNeeded = uiIsJITNeeded
+            delegate?.appLaunchAvailabilityDidChange()
         }
     }
     @Published var uiIsHidden : Bool
     @Published var uiIsLocked : Bool
     @Published var uiIsShared : Bool
-    @Published var uiDefaultDataFolder : String?
+    @Published var uiDefaultDataFolder : String? {
+        didSet {
+            appInfo.dataUUID = uiDefaultDataFolder
+            delegate?.appLaunchAvailabilityDidChange()
+        }
+    }
     @Published var uiContainers : [LCContainer]
     @Published var uiSelectedContainer : LCContainer?
 #if is32BitSupported
@@ -213,7 +220,6 @@ class LCAppModel: ObservableObject, Hashable {
             }
             appInfo.containers = uiContainers;
             newContainer.makeLCContainerInfoPlist(appIdentifier: appInfo.bundleIdentifier()!, keychainGroupId: Int.random(in: 0..<SharedModel.keychainAccessGroupCount))
-            appInfo.dataUUID = newName
             uiDefaultDataFolder = newName
         }
         if let containerFolderName {
@@ -415,6 +421,7 @@ class LCAppModel: ObservableObject, Hashable {
         
         if newLockState {
             appInfo.isLocked = true
+            delegate?.appLaunchAvailabilityDidChange()
         } else {
             // authenticate before cancelling locked state
             do {
@@ -433,6 +440,7 @@ class LCAppModel: ObservableObject, Hashable {
             if appInfo.isHidden {
                 await toggleHidden()
             }
+            delegate?.appLaunchAvailabilityDidChange()
         }
     }
     

--- a/LiveContainerSwiftUI/Utilities/Shared.swift
+++ b/LiveContainerSwiftUI/Utilities/Shared.swift
@@ -55,6 +55,8 @@ struct LCPath {
 class SharedModel: ObservableObject {
     static let guestURLSchemesKey = "LCGuestURLSchemes"
     static let guestURLLaunchMapKey = "LCGuestURLLaunchMap"
+    static let guestBundleLaunchMapKey = "LCGuestBundleLaunchMap"
+    static let guestDirectLaunchMapKey = "LCGuestDirectLaunchMap"
 
     @Published var selectedTab: LCTabIdentifier = .apps
     @Published var deepLink: URL?
@@ -115,11 +117,24 @@ class SharedModel: ObservableObject {
 
         let sharedDefaults = UserDefaults.lcShared() ?? .standard
         var launchMap = [String: String]()
+        var bundleLaunchMap = [String: String]()
+        var directLaunchMap = [String: String]()
         var schemes = Set<String>()
 
         for app in apps {
-            guard let bundleName = app.appInfo.relativeBundlePath,
-                  let rawSchemes = app.appInfo.urlSchemes() as? [String] else {
+            guard let bundleName = app.appInfo.relativeBundlePath else {
+                continue
+            }
+
+            if !app.appInfo.isHidden && !app.appInfo.isLocked && !app.appInfo.isJITNeeded {
+                directLaunchMap[bundleName] = app.appInfo.dataUUID ?? ""
+            }
+
+            if let bundleIdentifier = app.appInfo.bundleIdentifier(), !bundleIdentifier.isEmpty {
+                bundleLaunchMap[bundleIdentifier] = bundleName
+            }
+
+            guard let rawSchemes = app.appInfo.urlSchemes() as? [String] else {
                 continue
             }
 
@@ -137,6 +152,8 @@ class SharedModel: ObservableObject {
 
         sharedDefaults.set(Array(schemes).sorted(), forKey: Self.guestURLSchemesKey)
         sharedDefaults.set(launchMap, forKey: Self.guestURLLaunchMapKey)
+        sharedDefaults.set(bundleLaunchMap, forKey: Self.guestBundleLaunchMapKey)
+        sharedDefaults.set(directLaunchMap, forKey: Self.guestDirectLaunchMapKey)
     }
 
 }
@@ -288,23 +305,21 @@ struct SiteAssociationDetailItem : Codable {
     var appIDs: [String]?
     
     func getBundleIds() -> [String] {
-        var ans : [String] = []
-        // get rid of developer id
-        if let appID = appID, appID.count > 11 {
-            let index = appID.index(appID.startIndex, offsetBy: 11)
-            let modifiedString = String(appID[index...])
-            ans.append(modifiedString)
+        var ans: [String] = []
+        if let appID {
+            ans.append(bundleIdentifier(from: appID))
         }
-        if let appIDs = appIDs {
-            for appID in appIDs {
-                if appID.count > 11 {
-                    let index = appID.index(appID.startIndex, offsetBy: 11)
-                    let modifiedString = String(appID[index...])
-                    ans.append(modifiedString)
-                }
-            }
+        if let appIDs {
+            ans.append(contentsOf: appIDs.map { bundleIdentifier(from: $0) })
         }
-        return ans
+        return ans.filter { !$0.isEmpty }
+    }
+
+    private func bundleIdentifier(from appID: String) -> String {
+        guard let separator = appID.firstIndex(of: ".") else {
+            return ""
+        }
+        return String(appID[appID.index(after: separator)...])
     }
 }
 

--- a/LiveContainerSwiftUI/Utilities/Shared.swift
+++ b/LiveContainerSwiftUI/Utilities/Shared.swift
@@ -53,6 +53,9 @@ struct LCPath {
 }
 
 class SharedModel: ObservableObject {
+    static let guestURLSchemesKey = "LCGuestURLSchemes"
+    static let guestURLLaunchMapKey = "LCGuestURLLaunchMap"
+
     @Published var selectedTab: LCTabIdentifier = .apps
     @Published var deepLink: URL?
     
@@ -104,6 +107,38 @@ class SharedModel: ObservableObject {
     init() {
         updateMultiLCStatus()
     }
+
+    func syncSharedGuestURLIndex() {
+        guard multiLCStatus != 2 else {
+            return
+        }
+
+        let sharedDefaults = UserDefaults.lcShared() ?? .standard
+        var launchMap = [String: String]()
+        var schemes = Set<String>()
+
+        for app in apps {
+            guard let bundleName = app.appInfo.relativeBundlePath,
+                  let rawSchemes = app.appInfo.urlSchemes() as? [String] else {
+                continue
+            }
+
+            for rawScheme in rawSchemes {
+                let normalizedScheme = rawScheme.lowercased()
+                guard !normalizedScheme.isEmpty else {
+                    continue
+                }
+                schemes.insert(normalizedScheme)
+                if launchMap[normalizedScheme] == nil {
+                    launchMap[normalizedScheme] = bundleName
+                }
+            }
+        }
+
+        sharedDefaults.set(Array(schemes).sorted(), forKey: Self.guestURLSchemesKey)
+        sharedDefaults.set(launchMap, forKey: Self.guestURLLaunchMapKey)
+    }
+
 }
 
 class DataManager {

--- a/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
@@ -504,7 +504,6 @@ struct LCAppSettingsView: View {
         }
         if model.uiDefaultDataFolder == nil {
             model.uiDefaultDataFolder = newName
-            appInfo.dataUUID = newName
         }
         appInfo.containers = model.uiContainers;
         newContainer.makeLCContainerInfoPlist(appIdentifier: appInfo.bundleIdentifier()!, keychainGroupId: freeKeyChainGroup)
@@ -576,7 +575,6 @@ struct LCAppSettingsView: View {
             }
             if model.uiDefaultDataFolder == nil {
                 model.uiDefaultDataFolder = url.lastPathComponent
-                appInfo.dataUUID = url.lastPathComponent
             }
 
         } catch {
@@ -740,7 +738,6 @@ extension LCAppSettingsView : LCContainerViewDelegate {
         if model.uiContainers.isEmpty {
             model.uiSelectedContainer = nil
             model.uiDefaultDataFolder = nil
-            appInfo.dataUUID = nil
         }
         appInfo.containers = model.uiContainers
     }
@@ -750,7 +747,6 @@ extension LCAppSettingsView : LCContainerViewDelegate {
             model.uiSelectedContainer = newDefaultContainer
         }
         
-        appInfo.dataUUID = newDefaultContainer.folderName
         model.uiDefaultDataFolder = newDefaultContainer.folderName
     }
     
@@ -817,7 +813,6 @@ extension LCAppSettingsView : LCSelectContainerViewDelegate {
             }
             if model.uiDefaultDataFolder == nil {
                 model.uiDefaultDataFolder = folderName
-                appInfo.dataUUID = folderName
             }
 
 

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -774,14 +774,9 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             } else {
                 let newAppModel = LCAppModel(appInfo: finalNewApp, delegate: self)
                 sharedModel.apps.append(newAppModel)
-                
-                // add url schemes
-                if let urlSchemes = finalNewApp.urlSchemes(), urlSchemes.count > 0 {
-                    UserDefaults.lcShared().mutableArrayValue(forKey: "LCGuestURLSchemes")
-                        .addObjects(from: urlSchemes as! [Any])
-                }
             }
 
+            self.sharedModel.syncSharedGuestURLIndex()
             self.installprogressVisible = false
         }
     }
@@ -959,7 +954,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             sharedModel.hiddenApps.removeAll { now in
                 return app == now
             }
-            
+            self.sharedModel.syncSharedGuestURLIndex()
         }
     }
     
@@ -972,8 +967,6 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 if !sharedModel.hiddenApps.contains(app) {
                     sharedModel.hiddenApps.append(app)
                 }
-                UserDefaults.lcShared().mutableArrayValue(forKey: "LCGuestURLSchemes")
-                    .removeObjects(in: app.appInfo.urlSchemes() as! [Any])
             } else {
                 sharedModel.hiddenApps.removeAll { now in
                     return app == now
@@ -981,14 +974,13 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 if !sharedModel.apps.contains(app) {
                     sharedModel.apps.append(app)
                 }
-                UserDefaults.lcShared().mutableArrayValue(forKey: "LCGuestURLSchemes")
-                    .addObjects(from: app.appInfo.urlSchemes() as! [Any])
             }
-            
+
+            self.sharedModel.syncSharedGuestURLIndex()
         }
     }
     
-    func launchAppWithBundleId(bundleId : String, container : String?, forceJIT: Bool? = nil) async {
+    func launchAppWithBundleId(bundleId : String, container : String?, openURL: String? = nil, forceJIT: Bool? = nil) async {
         if bundleId == "" {
             return
         }
@@ -1029,6 +1021,33 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             errorInfo = "lc.appList.appNotFoundError".loc
             errorShow = true
             return
+        }
+
+        let targetContainer = container ?? appFound.uiDefaultDataFolder
+        if let openURL,
+           let targetContainer,
+           var runningLC = LCSharedUtils.getContainerUsingLCScheme(withFolderName: targetContainer) {
+            runningLC = (runningLC as NSString).deletingPathExtension
+            let encodedOpenURL = Data(openURL.utf8).base64EncodedString()
+            var components = URLComponents()
+            components.scheme = runningLC
+            components.host = "livecontainer-launch"
+            components.queryItems = [
+                URLQueryItem(name: "bundle-name", value: bundleId),
+                URLQueryItem(name: "container-folder-name", value: targetContainer),
+                URLQueryItem(name: "open-url", value: encodedOpenURL)
+            ]
+            if let forceJIT {
+                components.queryItems?.append(URLQueryItem(name: "jit", value: forceJIT ? "true" : "false"))
+            }
+            if let urlToOpen = components.url, UIApplication.shared.canOpenURL(urlToOpen) {
+                await UIApplication.shared.open(urlToOpen)
+                return
+            }
+        }
+
+        if let openURL {
+            UserDefaults.standard.setValue(openURL, forKey: "launchAppUrlScheme")
         }
 
         do {
@@ -1173,7 +1192,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             LCUtils.openSideStore(delegate: self)
             return
         }
-        
+
         if url.host == "open-web-page" || url.host == "open-url" {
             if let urlComponent = URLComponents(url: url, resolvingAgainstBaseURL: false), let queryItem = urlComponent.queryItems?.first {
                 if queryItem.value?.isEmpty ?? true {
@@ -1189,12 +1208,16 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
                 var bundleId : String? = nil
                 var containerName : String? = nil
+                var openURL : String? = nil
                 var forceJIT: Bool? = nil
                 for queryItem in components.queryItems ?? [] {
                     if queryItem.name == "bundle-name", let bundleId1 = queryItem.value {
                         bundleId = bundleId1
                     } else if queryItem.name == "container-folder-name", let containerName1 = queryItem.value {
                         containerName = containerName1
+                    } else if queryItem.name == "open-url", let encodedOpenURL = queryItem.value,
+                              let decodedData = Data(base64Encoded: encodedOpenURL) {
+                        openURL = String(data: decodedData, encoding: .utf8)
                     } else if queryItem.name == "jit", let forceJIT1 = queryItem.value {
                         if forceJIT1 == "true" {
                             forceJIT = true
@@ -1204,7 +1227,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                     }
                 }
                 if let bundleId, bundleId != "ui"{
-                    Task { await launchAppWithBundleId(bundleId: bundleId, container: containerName, forceJIT: forceJIT) }
+                    Task { await launchAppWithBundleId(bundleId: bundleId, container: containerName, openURL: openURL, forceJIT: forceJIT) }
                 }
             }
         } else if url.host == "install" {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -979,6 +979,12 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             self.sharedModel.syncSharedGuestURLIndex()
         }
     }
+
+    func appLaunchAvailabilityDidChange() {
+        DispatchQueue.main.async {
+            self.sharedModel.syncSharedGuestURLIndex()
+        }
+    }
     
     func launchAppWithBundleId(bundleId : String, container : String?, openURL: String? = nil, forceJIT: Bool? = nil) async {
         if bundleId == "" {

--- a/SafariWebExtension/Info.plist
+++ b/SafariWebExtension/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LiveContainerAppGroups</key>
+	<array>
+		<string>$(APP_GROUP_SIDESTORE)</string>
+		<string>$(APP_GROUP_ALTSTORE)</string>
+	</array>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.web-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/SafariWebExtension/Resources/background.js
+++ b/SafariWebExtension/Resources/background.js
@@ -1,11 +1,11 @@
 const runtimeAPI = typeof browser !== "undefined" ? browser : chrome;
 
 runtimeAPI.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message?.command === "getLaunchMap") {
+  if (message?.command === "launchResolved") {
     runtimeAPI.runtime
-      .sendNativeMessage("application.id", { command: "getLaunchMap" })
-      .then((response) => sendResponse({ ok: true, launchMap: response?.launchMap || {} }))
-      .catch(() => sendResponse({ ok: true, launchMap: {} }));
+      .sendNativeMessage("application.id", { command: "launchResolved", url: message.url })
+      .then((response) => sendResponse({ ok: response?.ok === true }))
+      .catch(() => sendResponse({ ok: false }));
     return true;
   }
 

--- a/SafariWebExtension/Resources/background.js
+++ b/SafariWebExtension/Resources/background.js
@@ -1,0 +1,13 @@
+const runtimeAPI = typeof browser !== "undefined" ? browser : chrome;
+
+runtimeAPI.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.command === "getLaunchMap") {
+    runtimeAPI.runtime
+      .sendNativeMessage("application.id", { command: "getLaunchMap" })
+      .then((response) => sendResponse({ ok: true, launchMap: response?.launchMap || {} }))
+      .catch(() => sendResponse({ ok: true, launchMap: {} }));
+    return true;
+  }
+
+  return false;
+});

--- a/SafariWebExtension/Resources/content.js
+++ b/SafariWebExtension/Resources/content.js
@@ -1,0 +1,372 @@
+(function () {
+  const BLOCKED_PROTOCOLS = new Set(["http:", "https:", "about:", "javascript:", "data:", "blob:"]);
+  const ATTRIBUTE_CANDIDATES = [
+    "schema",
+    "data-schema",
+    "deeplink",
+    "deep-link",
+    "deep_link",
+    "data-deeplink",
+    "data-deep-link",
+    "data-url",
+    "data-open-url",
+    "data-href",
+    "url",
+    "href",
+    "action"
+  ];
+  const MAX_ANCESTOR_DEPTH = 8;
+  const runtimeAPI = typeof browser !== "undefined" ? browser : typeof chrome !== "undefined" ? chrome : null;
+  const PAGE_LAUNCH_EVENT = "__LC_LAUNCH_REQUEST__";
+
+  function expandCandidates(rawValue) {
+    const values = new Set();
+    if (typeof rawValue !== "string") {
+      return [];
+    }
+
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    values.add(trimmed);
+
+    try {
+      const decoded = decodeURIComponent(trimmed);
+      if (decoded) {
+        values.add(decoded);
+      }
+    } catch (_) {}
+
+    try {
+      const decoded = atob(trimmed);
+      if (decoded) {
+        values.add(decoded);
+      }
+      try {
+        const twiceDecoded = decodeURIComponent(decoded);
+        if (twiceDecoded) {
+          values.add(twiceDecoded);
+        }
+      } catch (_) {}
+    } catch (_) {}
+
+    return [...values];
+  }
+
+  function resolveURL(rawValue) {
+    try {
+      return new URL(rawValue, window.location.href).href;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function extractExternalScheme(rawValue) {
+    for (const candidate of expandCandidates(rawValue)) {
+      const resolved = resolveURL(candidate);
+      if (!resolved) {
+        continue;
+      }
+
+      try {
+        const protocol = new URL(resolved).protocol.toLowerCase();
+        if (!BLOCKED_PROTOCOLS.has(protocol)) {
+          return resolved;
+        }
+      } catch (_) {}
+    }
+
+    return null;
+  }
+
+  function encodeBase64(value) {
+    return btoa(unescape(encodeURIComponent(value)));
+  }
+
+  function buildOpenURL(rawValue) {
+    return `livecontainer://open-url?url=${encodeURIComponent(encodeBase64(rawValue))}`;
+  }
+
+  function buildDirectLaunchURL(extracted, bundleName) {
+    const query = new URLSearchParams();
+    query.set("bundle-name", bundleName);
+    query.set("open-url", encodeBase64(extracted));
+    return `livecontainer://livecontainer-launch?${query.toString()}`;
+  }
+
+  function resolveLaunchTarget(rawValue, launchMap) {
+    const extracted = extractExternalScheme(rawValue);
+    if (!extracted) {
+      return null;
+    }
+
+    let scheme = null;
+    try {
+      scheme = new URL(extracted).protocol.replace(/:$/, "").toLowerCase();
+    } catch (_) {
+      return { type: "open", extracted, url: buildOpenURL(extracted) };
+    }
+
+    const bundleName = launchMap?.[scheme];
+    if (!bundleName) {
+      return { type: "open", extracted, url: buildOpenURL(extracted) };
+    }
+
+    return {
+      type: "direct",
+      extracted,
+      bundleName,
+      url: buildDirectLaunchURL(extracted, bundleName)
+    };
+  }
+
+  async function redirectToLiveContainer(rawValue, launchMap) {
+    const target = resolveLaunchTarget(rawValue, launchMap);
+    if (!target) {
+      return false;
+    }
+
+    window.location.href = target.url;
+    return true;
+  }
+
+  function extractFromElement(element) {
+    if (!(element instanceof Element)) {
+      return null;
+    }
+
+    for (const attribute of ATTRIBUTE_CANDIDATES) {
+      const value = element.getAttribute(attribute);
+      const extracted = extractExternalScheme(value);
+      if (extracted) {
+        return extracted;
+      }
+    }
+
+    return null;
+  }
+
+  function extractFromElementTree(element) {
+    let current = element;
+    let depth = 0;
+
+    while (current && depth < MAX_ANCESTOR_DEPTH) {
+      const directMatch = extractFromElement(current);
+      if (directMatch) {
+        return directMatch;
+      }
+
+      current = current.parentElement;
+      depth += 1;
+    }
+
+    return null;
+  }
+
+  function installPageLevelHooks() {
+    const script = document.createElement("script");
+    script.textContent = `
+      (() => {
+        const blockedProtocols = new Set(["http:", "https:", "about:", "javascript:", "data:", "blob:"]);
+        const pageLaunchEvent = ${JSON.stringify(PAGE_LAUNCH_EVENT)};
+
+        function expandCandidates(rawValue) {
+          const values = new Set();
+          if (typeof rawValue !== "string") {
+            return [];
+          }
+
+          const trimmed = rawValue.trim();
+          if (!trimmed) {
+            return [];
+          }
+
+          values.add(trimmed);
+
+          try {
+            const decoded = decodeURIComponent(trimmed);
+            if (decoded) {
+              values.add(decoded);
+            }
+          } catch (_) {}
+
+          try {
+            const decoded = atob(trimmed);
+            if (decoded) {
+              values.add(decoded);
+            }
+            try {
+              const twiceDecoded = decodeURIComponent(decoded);
+              if (twiceDecoded) {
+                values.add(twiceDecoded);
+              }
+            } catch (_) {}
+          } catch (_) {}
+
+          return [...values];
+        }
+
+        function extractExternalScheme(rawValue) {
+          for (const candidate of expandCandidates(rawValue)) {
+            try {
+              const resolved = new URL(candidate, window.location.href).href;
+              const protocol = new URL(resolved).protocol.toLowerCase();
+              if (!blockedProtocols.has(protocol)) {
+                return resolved;
+              }
+            } catch (_) {}
+          }
+          return null;
+        }
+
+        function dispatchLaunchRequest(rawValue) {
+          const extracted = extractExternalScheme(rawValue);
+          if (!extracted) {
+            return false;
+          }
+          window.dispatchEvent(new CustomEvent(pageLaunchEvent, {
+            detail: { rawValue: extracted }
+          }));
+          return true;
+        }
+
+        const originalWindowOpen = window.open;
+        window.open = function (url, ...args) {
+          if (dispatchLaunchRequest(url)) {
+            return null;
+          }
+          return originalWindowOpen.call(window, url, ...args);
+        };
+
+        const originalAssign = Location.prototype.assign;
+        Location.prototype.assign = function (value) {
+          if (dispatchLaunchRequest(value)) {
+            return;
+          }
+          return originalAssign.call(this, value);
+        };
+
+        const originalReplace = Location.prototype.replace;
+        Location.prototype.replace = function (value) {
+          if (dispatchLaunchRequest(value)) {
+            return;
+          }
+          return originalReplace.call(this, value);
+        };
+
+        const originalAnchorClick = HTMLAnchorElement.prototype.click;
+        HTMLAnchorElement.prototype.click = function (...args) {
+          const href = this.getAttribute("href");
+          if (dispatchLaunchRequest(href)) {
+            return;
+          }
+          return originalAnchorClick.apply(this, args);
+        };
+
+        const iframeSrcDescriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, "src");
+        if (iframeSrcDescriptor && typeof iframeSrcDescriptor.set === "function") {
+          Object.defineProperty(HTMLIFrameElement.prototype, "src", {
+            configurable: iframeSrcDescriptor.configurable,
+            enumerable: iframeSrcDescriptor.enumerable,
+            get: iframeSrcDescriptor.get,
+            set(value) {
+              if (dispatchLaunchRequest(value)) {
+                return value;
+              }
+              return iframeSrcDescriptor.set.call(this, value);
+            }
+          });
+        }
+
+        const originalSetAttribute = Element.prototype.setAttribute;
+        Element.prototype.setAttribute = function (name, value) {
+          const attrName = typeof name === "string" ? name.toLowerCase() : "";
+          if (this instanceof HTMLIFrameElement && attrName === "src" && dispatchLaunchRequest(value)) {
+            return;
+          }
+          return originalSetAttribute.call(this, name, value);
+        };
+
+        function redirectIframeIfNeeded(node) {
+          if (!(node instanceof HTMLIFrameElement)) {
+            return false;
+          }
+          return dispatchLaunchRequest(node.getAttribute("src") || node.src);
+        }
+
+        const originalAppendChild = Node.prototype.appendChild;
+        Node.prototype.appendChild = function (node) {
+          if (redirectIframeIfNeeded(node)) {
+            return node;
+          }
+          return originalAppendChild.call(this, node);
+        };
+
+        const originalInsertBefore = Node.prototype.insertBefore;
+        Node.prototype.insertBefore = function (node, child) {
+          if (redirectIframeIfNeeded(node)) {
+            return node;
+          }
+          return originalInsertBefore.call(this, node, child);
+        };
+      })();
+    `;
+
+    (document.documentElement || document.head || document.body).appendChild(script);
+    script.remove();
+  }
+
+  async function loadLaunchMap() {
+    if (!runtimeAPI?.runtime?.sendMessage) {
+      return {};
+    }
+
+    try {
+      const response = await runtimeAPI.runtime.sendMessage({ command: "getLaunchMap" });
+      return response?.launchMap || {};
+    } catch (_) {
+      return {};
+    }
+  }
+
+  async function init() {
+    const launchMapPromise = loadLaunchMap();
+    installPageLevelHooks();
+
+    window.addEventListener(PAGE_LAUNCH_EVENT, (event) => {
+      const rawValue = event?.detail?.rawValue;
+      if (!rawValue) {
+        return;
+      }
+      void launchMapPromise.then((launchMap) => redirectToLiveContainer(rawValue, launchMap));
+    });
+
+    document.addEventListener(
+      "click",
+      (event) => {
+        if (event.defaultPrevented) {
+          return;
+        }
+
+        const target = event.target instanceof Element ? event.target : null;
+        if (!target) {
+          return;
+        }
+
+        const extracted = extractFromElementTree(target);
+        if (!extracted) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+        void launchMapPromise.then((launchMap) => redirectToLiveContainer(extracted, launchMap));
+      },
+      true
+    );
+  }
+
+  void init();
+})();

--- a/SafariWebExtension/Resources/content.js
+++ b/SafariWebExtension/Resources/content.js
@@ -21,6 +21,7 @@
 
   function expandCandidates(rawValue) {
     const values = new Set();
+
     if (typeof rawValue !== "string") {
       return [];
     }
@@ -44,6 +45,7 @@
       if (decoded) {
         values.add(decoded);
       }
+
       try {
         const twiceDecoded = decodeURIComponent(decoded);
         if (twiceDecoded) {
@@ -62,9 +64,7 @@
         if (url.protocol && !BLOCKED_PROTOCOLS.has(url.protocol.toLowerCase())) {
           return url.href;
         }
-      } catch (_) {
-        continue;
-      }
+      } catch (_) {}
     }
 
     return null;
@@ -122,24 +122,65 @@
         const blockedProtocols = new Set(["http:", "https:", "about:", "javascript:", "data:", "blob:"]);
         const pageLaunchEvent = ${JSON.stringify(PAGE_LAUNCH_EVENT)};
 
-        function hasExternalScheme(rawValue) {
-          if (typeof rawValue !== "string" || rawValue.trim() === "") {
-            return false;
+        function expandCandidates(rawValue) {
+          const values = new Set();
+
+          if (typeof rawValue !== "string") {
+            return [];
           }
+
+          const trimmed = rawValue.trim();
+          if (!trimmed) {
+            return [];
+          }
+
+          values.add(trimmed);
+
           try {
-            const protocol = new URL(rawValue, window.location.href).protocol.toLowerCase();
-            return protocol && !blockedProtocols.has(protocol);
-          } catch (_) {
-            return false;
+            const decoded = decodeURIComponent(trimmed);
+            if (decoded) {
+              values.add(decoded);
+            }
+          } catch (_) {}
+
+          try {
+            const decoded = atob(trimmed);
+            if (decoded) {
+              values.add(decoded);
+            }
+
+            try {
+              const twiceDecoded = decodeURIComponent(decoded);
+              if (twiceDecoded) {
+                values.add(twiceDecoded);
+              }
+            } catch (_) {}
+          } catch (_) {}
+
+          return [...values];
+        }
+
+        function extractExternalScheme(rawValue) {
+          for (const candidate of expandCandidates(rawValue)) {
+            try {
+              const url = new URL(candidate, window.location.href);
+              if (url.protocol && !blockedProtocols.has(url.protocol.toLowerCase())) {
+                return url.href;
+              }
+            } catch (_) {}
           }
+
+          return null;
         }
 
         function dispatchLaunchRequest(rawValue) {
-          if (!hasExternalScheme(rawValue)) {
+          const extracted = extractExternalScheme(rawValue);
+          if (!extracted) {
             return false;
           }
+
           window.dispatchEvent(new CustomEvent(pageLaunchEvent, {
-            detail: { rawValue }
+            detail: { rawValue: extracted }
           }));
           return true;
         }
@@ -185,9 +226,9 @@
             get: iframeSrcDescriptor.get,
             set(value) {
               if (dispatchLaunchRequest(value)) {
-                return value;
+                return;
               }
-              return iframeSrcDescriptor.set.call(this, value);
+              iframeSrcDescriptor.set.call(this, value);
             }
           });
         }

--- a/SafariWebExtension/Resources/content.js
+++ b/SafariWebExtension/Resources/content.js
@@ -55,91 +55,28 @@
     return [...values];
   }
 
-  function resolveURL(rawValue) {
-    try {
-      return new URL(rawValue, window.location.href).href;
-    } catch (_) {
-      return null;
-    }
-  }
-
   function extractExternalScheme(rawValue) {
     for (const candidate of expandCandidates(rawValue)) {
-      const resolved = resolveURL(candidate);
-      if (!resolved) {
+      try {
+        const url = new URL(candidate, window.location.href);
+        if (url.protocol && !BLOCKED_PROTOCOLS.has(url.protocol.toLowerCase())) {
+          return url.href;
+        }
+      } catch (_) {
         continue;
       }
-
-      try {
-        const protocol = new URL(resolved).protocol.toLowerCase();
-        if (!BLOCKED_PROTOCOLS.has(protocol)) {
-          return resolved;
-        }
-      } catch (_) {}
     }
 
     return null;
   }
 
-  function encodeBase64(value) {
-    return btoa(unescape(encodeURIComponent(value)));
-  }
-
-  function buildOpenURL(rawValue) {
-    return `livecontainer://open-url?url=${encodeURIComponent(encodeBase64(rawValue))}`;
-  }
-
-  function buildDirectLaunchURL(extracted, bundleName) {
-    const query = new URLSearchParams();
-    query.set("bundle-name", bundleName);
-    query.set("open-url", encodeBase64(extracted));
-    return `livecontainer://livecontainer-launch?${query.toString()}`;
-  }
-
-  function resolveLaunchTarget(rawValue, launchMap) {
-    const extracted = extractExternalScheme(rawValue);
-    if (!extracted) {
-      return null;
-    }
-
-    let scheme = null;
-    try {
-      scheme = new URL(extracted).protocol.replace(/:$/, "").toLowerCase();
-    } catch (_) {
-      return { type: "open", extracted, url: buildOpenURL(extracted) };
-    }
-
-    const bundleName = launchMap?.[scheme];
-    if (!bundleName) {
-      return { type: "open", extracted, url: buildOpenURL(extracted) };
-    }
-
-    return {
-      type: "direct",
-      extracted,
-      bundleName,
-      url: buildDirectLaunchURL(extracted, bundleName)
-    };
-  }
-
-  async function redirectToLiveContainer(rawValue, launchMap) {
-    const target = resolveLaunchTarget(rawValue, launchMap);
-    if (!target) {
-      return false;
-    }
-
-    window.location.href = target.url;
-    return true;
-  }
-
-  function extractFromElement(element) {
+  function extractExternalSchemeFromElement(element) {
     if (!(element instanceof Element)) {
       return null;
     }
 
     for (const attribute of ATTRIBUTE_CANDIDATES) {
-      const value = element.getAttribute(attribute);
-      const extracted = extractExternalScheme(value);
+      const extracted = extractExternalScheme(element.getAttribute(attribute));
       if (extracted) {
         return extracted;
       }
@@ -148,12 +85,12 @@
     return null;
   }
 
-  function extractFromElementTree(element) {
+  function extractExternalSchemeFromTree(element) {
     let current = element;
     let depth = 0;
 
     while (current && depth < MAX_ANCESTOR_DEPTH) {
-      const directMatch = extractFromElement(current);
+      const directMatch = extractExternalSchemeFromElement(current);
       if (directMatch) {
         return directMatch;
       }
@@ -165,6 +102,19 @@
     return null;
   }
 
+  function requestLaunch(url) {
+    if (!runtimeAPI?.runtime?.sendMessage || !url) {
+      return;
+    }
+
+    runtimeAPI.runtime
+      .sendMessage({
+        command: "launchResolved",
+        url
+      })
+      .catch(() => {});
+  }
+
   function installPageLevelHooks() {
     const script = document.createElement("script");
     script.textContent = `
@@ -172,62 +122,24 @@
         const blockedProtocols = new Set(["http:", "https:", "about:", "javascript:", "data:", "blob:"]);
         const pageLaunchEvent = ${JSON.stringify(PAGE_LAUNCH_EVENT)};
 
-        function expandCandidates(rawValue) {
-          const values = new Set();
-          if (typeof rawValue !== "string") {
-            return [];
+        function hasExternalScheme(rawValue) {
+          if (typeof rawValue !== "string" || rawValue.trim() === "") {
+            return false;
           }
-
-          const trimmed = rawValue.trim();
-          if (!trimmed) {
-            return [];
-          }
-
-          values.add(trimmed);
-
           try {
-            const decoded = decodeURIComponent(trimmed);
-            if (decoded) {
-              values.add(decoded);
-            }
-          } catch (_) {}
-
-          try {
-            const decoded = atob(trimmed);
-            if (decoded) {
-              values.add(decoded);
-            }
-            try {
-              const twiceDecoded = decodeURIComponent(decoded);
-              if (twiceDecoded) {
-                values.add(twiceDecoded);
-              }
-            } catch (_) {}
-          } catch (_) {}
-
-          return [...values];
-        }
-
-        function extractExternalScheme(rawValue) {
-          for (const candidate of expandCandidates(rawValue)) {
-            try {
-              const resolved = new URL(candidate, window.location.href).href;
-              const protocol = new URL(resolved).protocol.toLowerCase();
-              if (!blockedProtocols.has(protocol)) {
-                return resolved;
-              }
-            } catch (_) {}
+            const protocol = new URL(rawValue, window.location.href).protocol.toLowerCase();
+            return protocol && !blockedProtocols.has(protocol);
+          } catch (_) {
+            return false;
           }
-          return null;
         }
 
         function dispatchLaunchRequest(rawValue) {
-          const extracted = extractExternalScheme(rawValue);
-          if (!extracted) {
+          if (!hasExternalScheme(rawValue)) {
             return false;
           }
           window.dispatchEvent(new CustomEvent(pageLaunchEvent, {
-            detail: { rawValue: extracted }
+            detail: { rawValue }
           }));
           return true;
         }
@@ -318,29 +230,29 @@
     script.remove();
   }
 
-  async function loadLaunchMap() {
-    if (!runtimeAPI?.runtime?.sendMessage) {
-      return {};
+  function attemptInitialHTTPSRedirect() {
+    if (window.top !== window) {
+      return;
     }
 
-    try {
-      const response = await runtimeAPI.runtime.sendMessage({ command: "getLaunchMap" });
-      return response?.launchMap || {};
-    } catch (_) {
-      return {};
+    if (window.location.protocol !== "https:") {
+      return;
     }
+
+    requestLaunch(window.location.href);
   }
 
-  async function init() {
-    const launchMapPromise = loadLaunchMap();
+  function init() {
     installPageLevelHooks();
 
+    attemptInitialHTTPSRedirect();
+
     window.addEventListener(PAGE_LAUNCH_EVENT, (event) => {
-      const rawValue = event?.detail?.rawValue;
-      if (!rawValue) {
+      const extracted = extractExternalScheme(event?.detail?.rawValue);
+      if (!extracted) {
         return;
       }
-      void launchMapPromise.then((launchMap) => redirectToLiveContainer(rawValue, launchMap));
+      requestLaunch(extracted);
     });
 
     document.addEventListener(
@@ -355,18 +267,18 @@
           return;
         }
 
-        const extracted = extractFromElementTree(target);
+        const extracted = extractExternalSchemeFromTree(target);
         if (!extracted) {
           return;
         }
 
         event.preventDefault();
         event.stopPropagation();
-        void launchMapPromise.then((launchMap) => redirectToLiveContainer(extracted, launchMap));
+        requestLaunch(extracted);
       },
       true
     );
   }
 
-  void init();
+  init();
 })();

--- a/SafariWebExtension/Resources/manifest.json
+++ b/SafariWebExtension/Resources/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 3,
+  "name": "LiveContainer Scheme Bridge",
+  "description": "Redirect custom URL schemes from Safari to LiveContainer.",
+  "version": "1.0",
+  "permissions": [
+    "nativeMessaging"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ]
+}

--- a/SafariWebExtension/SafariWebExtension.entitlements
+++ b/SafariWebExtension/SafariWebExtension.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_SIDESTORE)</string>
+		<string>$(APP_GROUP_ALTSTORE)</string>
+	</array>
+</dict>
+</plist>

--- a/SafariWebExtension/SafariWebExtensionHandler.swift
+++ b/SafariWebExtension/SafariWebExtensionHandler.swift
@@ -35,20 +35,13 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
     private func handleMessage(_ message: Any?) async -> [String: Any] {
         guard let body = message as? [String: Any],
-              let command = body["command"] as? String else {
-            return ["ok": true]
+              body["command"] as? String == "launchResolved",
+              let urlString = body["url"] as? String,
+              let url = URL(string: urlString) else {
+            return ["ok": false]
         }
 
-        switch command {
-        case "launchResolved":
-            guard let urlString = body["url"] as? String,
-                  let url = URL(string: urlString) else {
-                return ["ok": false]
-            }
-            return ["ok": await launchResolved(url)]
-        default:
-            return ["ok": true]
-        }
+        return ["ok": await launchResolved(url)]
     }
 
     private func sharedMap(forKey key: String) -> [String: String] {
@@ -87,8 +80,8 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
     }
 
     private func resolveUniversalLink(_ url: URL) async -> String? {
-        guard url.scheme == "https",
-              let host = url.host,
+        guard url.scheme?.lowercased() == "https",
+              let host = url.host?.lowercased(),
               let siteAssociation = await loadSiteAssociation(host: host),
               let details = siteAssociation.applinks?.details else {
             return nil
@@ -157,12 +150,15 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         guard let helper = launchHelper() else {
             return false
         }
+
         let item = NSExtensionItem()
         item.userInfo = ["url": url]
+
         let selector = NSSelectorFromString("beginExtensionRequestWithInputItems:completion:")
         guard helper.responds(to: selector) else {
             return false
         }
+
         _ = helper.perform(selector, with: [item], with: nil)
         return true
     }
@@ -175,39 +171,45 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         let parentBundleIdentifier = (Bundle.main.bundleIdentifier! as NSString).deletingPathExtension
         let helperIdentifier = (parentBundleIdentifier as NSString).appendingPathExtension("LaunchAppExtensionHelper")
         let selector = NSSelectorFromString("extensionWithIdentifier:error:")
+
         guard let extensionClass = NSClassFromString("NSExtension") as? NSObject.Type,
               extensionClass.responds(to: selector),
               let helper = extensionClass.perform(selector, with: helperIdentifier, with: nil)?.takeUnretainedValue() else {
             return nil
         }
+
         Self.launchHelperExtension = helper
         return helper
     }
 
     private func loadSiteAssociation(host: String) async -> SiteAssociation? {
-        if let cached = Self.siteAssociationCache[host] {
+        let normalizedHost = host.lowercased()
+
+        if let cached = Self.siteAssociationCache[normalizedHost] {
             return cached
         }
-        if Self.failedSiteAssociationHosts.contains(host) {
+
+        if Self.failedSiteAssociationHosts.contains(normalizedHost) {
             return nil
         }
 
         let urls = [
-            URL(string: "https://\(host)/apple-app-site-association"),
-            URL(string: "https://\(host)/.well-known/apple-app-site-association")
+            URL(string: "https://\(normalizedHost)/apple-app-site-association"),
+            URL(string: "https://\(normalizedHost)/.well-known/apple-app-site-association")
         ].compactMap { $0 }
 
         for url in urls {
             do {
                 let (data, _) = try await URLSession.shared.data(from: url)
                 let siteAssociation = try JSONDecoder().decode(SiteAssociation.self, from: data)
-                Self.siteAssociationCache[host] = siteAssociation
+                Self.siteAssociationCache[normalizedHost] = siteAssociation
                 return siteAssociation
             } catch {
                 continue
             }
         }
-        Self.failedSiteAssociationHosts.insert(host)
+
+        Self.failedSiteAssociationHosts.insert(normalizedHost)
         return nil
     }
 
@@ -239,6 +241,7 @@ private struct AppLinks: Decodable {
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+
         if let arrayDetails = try? container.decode([SiteAssociationDetailItem].self, forKey: .details) {
             details = arrayDetails
             return
@@ -282,20 +285,16 @@ private struct SiteAssociationDetailItem: Decodable {
 
     func getBundleIds() -> [String] {
         var identifiers = [String]()
+
         if let appID {
             identifiers.append(bundleIdentifier(from: appID))
         }
+
         if let appIDs {
             identifiers.append(contentsOf: appIDs.map { bundleIdentifier(from: $0) })
         }
-        return identifiers.filter { !$0.isEmpty }
-    }
 
-    private func bundleIdentifier(from appID: String) -> String {
-        guard let separator = appID.firstIndex(of: ".") else {
-            return ""
-        }
-        return String(appID[appID.index(after: separator)...])
+        return identifiers.filter { !$0.isEmpty }
     }
 
     func matches(url: URL) -> Bool {
@@ -312,22 +311,31 @@ private struct SiteAssociationDetailItem: Decodable {
 
     private func matches(url: URL, paths: [String]) -> Bool {
         let path = url.path.isEmpty ? "/" : url.path
-        var didMatchInclude = false
 
         for rule in paths {
             let trimmedRule = rule.trimmingCharacters(in: .whitespacesAndNewlines)
-            let isExclude = trimmedRule.hasPrefix("NOT ")
-            let pattern = isExclude ? String(trimmedRule.dropFirst(4)) : trimmedRule
-            guard matchAASAPath(path, pattern: pattern) else {
+            guard !trimmedRule.isEmpty else {
                 continue
             }
-            if isExclude {
-                return false
+
+            let isExclude = trimmedRule.hasPrefix("NOT ")
+            let pattern = isExclude
+                ? String(trimmedRule.dropFirst(4)).trimmingCharacters(in: .whitespacesAndNewlines)
+                : trimmedRule
+
+            if matchWildcard(value: path, pattern: pattern) {
+                return !isExclude
             }
-            didMatchInclude = true
         }
 
-        return didMatchInclude
+        return false
+    }
+
+    private func bundleIdentifier(from appID: String) -> String {
+        guard let separator = appID.firstIndex(of: ".") else {
+            return ""
+        }
+        return String(appID[appID.index(after: separator)...])
     }
 }
 
@@ -367,6 +375,7 @@ private struct SiteAssociationComponent: Decodable {
                 guard let actualValue = queryItems.first(where: { $0.name == key })?.value else {
                     return false
                 }
+
                 if !expectedValue.matches(value: actualValue) {
                     return false
                 }
@@ -383,10 +392,12 @@ private enum StringOrBool: Decodable {
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
+
         if let stringValue = try? container.decode(String.self) {
             self = .string(stringValue)
             return
         }
+
         self = .bool(try container.decode(Bool.self))
     }
 
@@ -401,7 +412,7 @@ private enum StringOrBool: Decodable {
 }
 
 private func matchWildcard(value: String, pattern: String) -> Bool {
-    if pattern == "*" {
+    if pattern == "*" || pattern == "/*" {
         return true
     }
 
@@ -410,16 +421,4 @@ private func matchWildcard(value: String, pattern: String) -> Bool {
     }
 
     return value == pattern
-}
-
-private func matchAASAPath(_ path: String, pattern: String) -> Bool {
-    if pattern == "*" || pattern == "/*" {
-        return true
-    }
-
-    if pattern.hasSuffix("*") {
-        return path.hasPrefix(String(pattern.dropLast()))
-    }
-
-    return path == pattern
 }

--- a/SafariWebExtension/SafariWebExtensionHandler.swift
+++ b/SafariWebExtension/SafariWebExtensionHandler.swift
@@ -1,0 +1,61 @@
+import SafariServices
+
+final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    private static let launchMapKey = "LCGuestURLLaunchMap"
+
+    func beginRequest(with context: NSExtensionContext) {
+        let request = context.inputItems.first as? NSExtensionItem
+        let message: Any?
+        if #available(iOS 15.0, *) {
+            message = request?.userInfo?[SFExtensionMessageKey]
+        } else {
+            message = request?.userInfo?["message"]
+        }
+
+        let payload = handleMessage(message)
+        let response = NSExtensionItem()
+        if #available(iOS 15.0, *) {
+            response.userInfo = [SFExtensionMessageKey: payload]
+        } else {
+            response.userInfo = ["message": payload]
+        }
+        context.completeRequest(returningItems: [response], completionHandler: nil)
+    }
+
+    private func handleMessage(_ message: Any?) -> [String: Any] {
+        guard let body = message as? [String: Any],
+              let command = body["command"] as? String else {
+            return ["ok": true]
+        }
+
+        switch command {
+        case "getLaunchMap":
+            return [
+                "ok": true,
+                "launchMap": sharedLaunchMap()
+            ]
+        default:
+            return ["ok": true]
+        }
+    }
+
+    private func sharedLaunchMap() -> [String: String] {
+        for defaults in candidateDefaults() {
+            guard let launchMap = defaults.dictionary(forKey: Self.launchMapKey) as? [String: String],
+                  !launchMap.isEmpty else {
+                continue
+            }
+            return launchMap
+        }
+        return [:]
+    }
+
+    private func configuredAppGroups() -> [String] {
+        (Bundle.main.object(forInfoDictionaryKey: "LiveContainerAppGroups") as? [String] ?? [])
+            .filter { !$0.isEmpty }
+    }
+
+    private func candidateDefaults() -> [UserDefaults] {
+        configuredAppGroups().compactMap { UserDefaults(suiteName: $0) }
+    }
+}

--- a/SafariWebExtension/SafariWebExtensionHandler.swift
+++ b/SafariWebExtension/SafariWebExtensionHandler.swift
@@ -2,6 +2,15 @@ import SafariServices
 
 final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
     private static let launchMapKey = "LCGuestURLLaunchMap"
+    private static let bundleLaunchMapKey = "LCGuestBundleLaunchMap"
+    private static let directLaunchMapKey = "LCGuestDirectLaunchMap"
+    private static let launchExtensionBundleIDKey = "LCLaunchExtensionBundleID"
+    private static let launchExtensionContainerNameKey = "LCLaunchExtensionContainerName"
+    private static let launchExtensionLaunchDateKey = "LCLaunchExtensionLaunchDate"
+    private static let launchExtensionOpenURLKey = "LCLaunchExtensionOpenURL"
+    private static var launchHelperExtension: AnyObject?
+    private static var siteAssociationCache = [String: SiteAssociation]()
+    private static var failedSiteAssociationHosts = Set<String>()
 
     func beginRequest(with context: NSExtensionContext) {
         let request = context.inputItems.first as? NSExtensionItem
@@ -12,42 +21,194 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             message = request?.userInfo?["message"]
         }
 
-        let payload = handleMessage(message)
-        let response = NSExtensionItem()
-        if #available(iOS 15.0, *) {
-            response.userInfo = [SFExtensionMessageKey: payload]
-        } else {
-            response.userInfo = ["message": payload]
+        Task {
+            let payload = await handleMessage(message)
+            let response = NSExtensionItem()
+            if #available(iOS 15.0, *) {
+                response.userInfo = [SFExtensionMessageKey: payload]
+            } else {
+                response.userInfo = ["message": payload]
+            }
+            context.completeRequest(returningItems: [response], completionHandler: nil)
         }
-        context.completeRequest(returningItems: [response], completionHandler: nil)
     }
 
-    private func handleMessage(_ message: Any?) -> [String: Any] {
+    private func handleMessage(_ message: Any?) async -> [String: Any] {
         guard let body = message as? [String: Any],
               let command = body["command"] as? String else {
             return ["ok": true]
         }
 
         switch command {
-        case "getLaunchMap":
-            return [
-                "ok": true,
-                "launchMap": sharedLaunchMap()
-            ]
+        case "launchResolved":
+            guard let urlString = body["url"] as? String,
+                  let url = URL(string: urlString) else {
+                return ["ok": false]
+            }
+            return ["ok": await launchResolved(url)]
         default:
             return ["ok": true]
         }
     }
 
-    private func sharedLaunchMap() -> [String: String] {
+    private func sharedMap(forKey key: String) -> [String: String] {
         for defaults in candidateDefaults() {
-            guard let launchMap = defaults.dictionary(forKey: Self.launchMapKey) as? [String: String],
+            guard let launchMap = defaults.dictionary(forKey: key) as? [String: String],
                   !launchMap.isEmpty else {
                 continue
             }
             return launchMap
         }
         return [:]
+    }
+
+    private func launchResolved(_ url: URL) async -> Bool {
+        guard let target = await launchTarget(for: url) else {
+            return false
+        }
+        return launch(target)
+    }
+
+    private func launchTarget(for url: URL) async -> LaunchTarget? {
+        let scheme = (url.scheme ?? "").lowercased()
+        if !scheme.isEmpty && scheme != "http" && scheme != "https" {
+            if let bundleName = sharedMap(forKey: Self.launchMapKey)[scheme] {
+                return LaunchTarget(bundleName: bundleName, openURL: url)
+            }
+            return nil
+        }
+
+        guard scheme == "https",
+              let bundleName = await resolveUniversalLink(url) else {
+            return nil
+        }
+
+        return LaunchTarget(bundleName: bundleName, openURL: url)
+    }
+
+    private func resolveUniversalLink(_ url: URL) async -> String? {
+        guard url.scheme == "https",
+              let host = url.host,
+              let siteAssociation = await loadSiteAssociation(host: host),
+              let details = siteAssociation.applinks?.details else {
+            return nil
+        }
+
+        let bundleLaunchMap = sharedMap(forKey: Self.bundleLaunchMapKey)
+        for item in details {
+            guard item.matches(url: url) else {
+                continue
+            }
+
+            for bundleIdentifier in item.getBundleIds() {
+                if let bundleName = bundleLaunchMap[bundleIdentifier] {
+                    return bundleName
+                }
+            }
+        }
+        return nil
+    }
+
+    private func launchURL(for target: LaunchTarget) -> URL? {
+        let encodedOpenURL = Data(target.openURL.absoluteString.utf8).base64EncodedString()
+        var components = URLComponents()
+        components.scheme = "livecontainer"
+        components.host = "livecontainer-launch"
+        components.queryItems = [
+            URLQueryItem(name: "bundle-name", value: target.bundleName),
+            URLQueryItem(name: "open-url", value: encodedOpenURL)
+        ]
+        return components.url
+    }
+
+    private func prepareDirectLaunch(_ target: LaunchTarget) -> Bool {
+        guard let (defaults, containerName) = directLaunchEntry(for: target.bundleName) else {
+            return false
+        }
+
+        defaults.set(target.bundleName, forKey: Self.launchExtensionBundleIDKey)
+        defaults.set(containerName, forKey: Self.launchExtensionContainerNameKey)
+        defaults.set(target.openURL.absoluteString, forKey: Self.launchExtensionOpenURLKey)
+        defaults.set(Date.now, forKey: Self.launchExtensionLaunchDateKey)
+        return defaults.synchronize()
+    }
+
+    private func directLaunchEntry(for bundleName: String) -> (defaults: UserDefaults, containerName: String)? {
+        for defaults in candidateDefaults() {
+            guard let launchMap = defaults.dictionary(forKey: Self.directLaunchMapKey) as? [String: String],
+                  let containerName = launchMap[bundleName] else {
+                continue
+            }
+            return (defaults, containerName)
+        }
+        return nil
+    }
+
+    private func launch(_ target: LaunchTarget) -> Bool {
+        guard let launchURL = launchURL(for: target) else {
+            return false
+        }
+
+        _ = prepareDirectLaunch(target)
+        return openWithLaunchHelper(launchURL)
+    }
+
+    private func openWithLaunchHelper(_ url: URL) -> Bool {
+        guard let helper = launchHelper() else {
+            return false
+        }
+        let item = NSExtensionItem()
+        item.userInfo = ["url": url]
+        let selector = NSSelectorFromString("beginExtensionRequestWithInputItems:completion:")
+        guard helper.responds(to: selector) else {
+            return false
+        }
+        _ = helper.perform(selector, with: [item], with: nil)
+        return true
+    }
+
+    private func launchHelper() -> AnyObject? {
+        if let helper = Self.launchHelperExtension {
+            return helper
+        }
+
+        let parentBundleIdentifier = (Bundle.main.bundleIdentifier! as NSString).deletingPathExtension
+        let helperIdentifier = (parentBundleIdentifier as NSString).appendingPathExtension("LaunchAppExtensionHelper")
+        let selector = NSSelectorFromString("extensionWithIdentifier:error:")
+        guard let extensionClass = NSClassFromString("NSExtension") as? NSObject.Type,
+              extensionClass.responds(to: selector),
+              let helper = extensionClass.perform(selector, with: helperIdentifier, with: nil)?.takeUnretainedValue() else {
+            return nil
+        }
+        Self.launchHelperExtension = helper
+        return helper
+    }
+
+    private func loadSiteAssociation(host: String) async -> SiteAssociation? {
+        if let cached = Self.siteAssociationCache[host] {
+            return cached
+        }
+        if Self.failedSiteAssociationHosts.contains(host) {
+            return nil
+        }
+
+        let urls = [
+            URL(string: "https://\(host)/apple-app-site-association"),
+            URL(string: "https://\(host)/.well-known/apple-app-site-association")
+        ].compactMap { $0 }
+
+        for url in urls {
+            do {
+                let (data, _) = try await URLSession.shared.data(from: url)
+                let siteAssociation = try JSONDecoder().decode(SiteAssociation.self, from: data)
+                Self.siteAssociationCache[host] = siteAssociation
+                return siteAssociation
+            } catch {
+                continue
+            }
+        }
+        Self.failedSiteAssociationHosts.insert(host)
+        return nil
     }
 
     private func configuredAppGroups() -> [String] {
@@ -58,4 +219,207 @@ final class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
     private func candidateDefaults() -> [UserDefaults] {
         configuredAppGroups().compactMap { UserDefaults(suiteName: $0) }
     }
+}
+
+private struct LaunchTarget {
+    let bundleName: String
+    let openURL: URL
+}
+
+private struct SiteAssociation: Decodable {
+    let applinks: AppLinks?
+}
+
+private struct AppLinks: Decodable {
+    let details: [SiteAssociationDetailItem]?
+
+    private enum CodingKeys: String, CodingKey {
+        case details
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let arrayDetails = try? container.decode([SiteAssociationDetailItem].self, forKey: .details) {
+            details = arrayDetails
+            return
+        }
+
+        if let dictionaryDetails = try? container.decode([String: SiteAssociationDetailValue].self, forKey: .details) {
+            details = dictionaryDetails.keys.sorted().map { key in
+                let value = dictionaryDetails[key]
+                return SiteAssociationDetailItem(
+                    appID: key,
+                    appIDs: value?.appIDs,
+                    paths: value?.paths,
+                    components: value?.components
+                )
+            }
+            return
+        }
+
+        details = nil
+    }
+}
+
+private struct SiteAssociationDetailValue: Decodable {
+    let appIDs: [String]?
+    let paths: [String]?
+    let components: [SiteAssociationComponent]?
+}
+
+private struct SiteAssociationDetailItem: Decodable {
+    let appID: String?
+    let appIDs: [String]?
+    let paths: [String]?
+    let components: [SiteAssociationComponent]?
+
+    init(appID: String?, appIDs: [String]?, paths: [String]? = nil, components: [SiteAssociationComponent]? = nil) {
+        self.appID = appID
+        self.appIDs = appIDs
+        self.paths = paths
+        self.components = components
+    }
+
+    func getBundleIds() -> [String] {
+        var identifiers = [String]()
+        if let appID {
+            identifiers.append(bundleIdentifier(from: appID))
+        }
+        if let appIDs {
+            identifiers.append(contentsOf: appIDs.map { bundleIdentifier(from: $0) })
+        }
+        return identifiers.filter { !$0.isEmpty }
+    }
+
+    private func bundleIdentifier(from appID: String) -> String {
+        guard let separator = appID.firstIndex(of: ".") else {
+            return ""
+        }
+        return String(appID[appID.index(after: separator)...])
+    }
+
+    func matches(url: URL) -> Bool {
+        if let components, !components.isEmpty {
+            return components.first(where: { $0.matches(url: url) }).map { !$0.exclude } ?? false
+        }
+
+        if let paths, !paths.isEmpty {
+            return matches(url: url, paths: paths)
+        }
+
+        return true
+    }
+
+    private func matches(url: URL, paths: [String]) -> Bool {
+        let path = url.path.isEmpty ? "/" : url.path
+        var didMatchInclude = false
+
+        for rule in paths {
+            let trimmedRule = rule.trimmingCharacters(in: .whitespacesAndNewlines)
+            let isExclude = trimmedRule.hasPrefix("NOT ")
+            let pattern = isExclude ? String(trimmedRule.dropFirst(4)) : trimmedRule
+            guard matchAASAPath(path, pattern: pattern) else {
+                continue
+            }
+            if isExclude {
+                return false
+            }
+            didMatchInclude = true
+        }
+
+        return didMatchInclude
+    }
+}
+
+private struct SiteAssociationComponent: Decodable {
+    let path: String?
+    let query: [String: StringOrBool]?
+    let fragment: String?
+    let exclude: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case path = "/"
+        case query = "?"
+        case fragment = "#"
+        case exclude
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decodeIfPresent(String.self, forKey: .path)
+        query = try container.decodeIfPresent([String: StringOrBool].self, forKey: .query)
+        fragment = try container.decodeIfPresent(String.self, forKey: .fragment)
+        exclude = try container.decodeIfPresent(Bool.self, forKey: .exclude) ?? false
+    }
+
+    func matches(url: URL) -> Bool {
+        if let path, !matchWildcard(value: url.path.isEmpty ? "/" : url.path, pattern: path) {
+            return false
+        }
+
+        if let fragment, !matchWildcard(value: url.fragment ?? "", pattern: fragment) {
+            return false
+        }
+
+        if let query {
+            let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+            for (key, expectedValue) in query {
+                guard let actualValue = queryItems.first(where: { $0.name == key })?.value else {
+                    return false
+                }
+                if !expectedValue.matches(value: actualValue) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+}
+
+private enum StringOrBool: Decodable {
+    case string(String)
+    case bool(Bool)
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
+            return
+        }
+        self = .bool(try container.decode(Bool.self))
+    }
+
+    func matches(value: String) -> Bool {
+        switch self {
+        case .string(let expectedValue):
+            return matchWildcard(value: value, pattern: expectedValue)
+        case .bool(let expectedValue):
+            return expectedValue ? !value.isEmpty : value.isEmpty
+        }
+    }
+}
+
+private func matchWildcard(value: String, pattern: String) -> Bool {
+    if pattern == "*" {
+        return true
+    }
+
+    if pattern.hasSuffix("*") {
+        return value.hasPrefix(String(pattern.dropLast()))
+    }
+
+    return value == pattern
+}
+
+private func matchAASAPath(_ path: String, pattern: String) -> Bool {
+    if pattern == "*" || pattern == "/*" {
+        return true
+    }
+
+    if pattern.hasSuffix("*") {
+        return path.hasPrefix(String(pattern.dropLast()))
+    }
+
+    return path == pattern
 }

--- a/xcconfigs/SafariWebExtension.xcconfig
+++ b/xcconfigs/SafariWebExtension.xcconfig
@@ -1,0 +1,8 @@
+//
+//  SafariWebExtension.xcconfig
+//  LiveContainer
+//
+
+#include "Global.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = $(LIVECONTAINER_BUNDLE_IDENTIFIER).SafariWebExtension


### PR DESCRIPTION
adds a Safari Web Extension bridge that lets Safari web pages launch installed LiveContainer guest apps through custom URL schemes and supported Universal Links.

- Intercept common web launch paths, including:
  - links and common deeplink attributes
  - `window.open`
  - `location.assign` / `location.replace`
  - programmatic anchor clicks
  - iframe-based scheme launches
- Support URL-encoded and base64-encoded launch URLs.
- Resolve custom schemes through LiveContainer’s shared launch map.
- Resolve Universal Links through `apple-app-site-association`.
- Add shared maps for scheme, bundle identifier, and direct launch resolution.
