### PR TITLE
Fix IPA download network drop and tab switch

### DIFF
--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -58,7 +58,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
     @State var webViewURL : URL = URL(string: "about:blank")!
     @StateObject private var webViewUrlInput = InputHelper()
     
-    @ObservedObject var downloadHelper = DownloadHelper()
+    @EnvironmentObject var downloadHelper: DownloadHelper
     @StateObject private var installUrlInput = InputHelper()
     
     @State private var jitLog = ""
@@ -386,7 +386,6 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 installUrlInput.close(result: nil)
             }
         )
-        .downloadAlert(helper: downloadHelper)
         .sheet(isPresented: $jitAlert.show, onDismiss: {
             jitAlert.close(result: false)
         }) {

--- a/LiveContainerSwiftUI/Views/AppList/LCDownloadView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCDownloadView.swift
@@ -31,7 +31,9 @@ public final class DownloadHelper : ObservableObject {
         
         await withUnsafeContinuation { c in
             continuation = c
-            let session = URLSession(configuration: .default, delegate: DownloadDelegate(progressCallback: { progress, downloaded, total in
+            
+            let bgConfig = URLSessionConfiguration.background(withIdentifier: "com.livecontainer.download.\(UUID().uuidString)")
+            let session = URLSession(configuration: bgConfig, delegate: DownloadDelegate(progressCallback: { progress, downloaded, total in
                 Task{ await MainActor.run {
                     self.downloadProgress = progress
                     self.downloadedSize = downloaded

--- a/LiveContainerSwiftUI/Views/LCTabView.swift
+++ b/LiveContainerSwiftUI/Views/LCTabView.swift
@@ -22,6 +22,8 @@ struct LCTabView: View {
     @EnvironmentObject var sceneDelegate: SceneDelegate
     @State var shouldToggleMainWindowOpen = false
     @Environment(\.scenePhase) var scenePhase
+    @StateObject var downloadHelper = DownloadHelper()
+    
     let pub = NotificationCenter.default.publisher(for: UIScene.didDisconnectNotification)
 
     
@@ -88,6 +90,8 @@ struct LCTabView: View {
                 }
             }
         }
+        .downloadAlert(helper: downloadHelper)
+        .environmentObject(downloadHelper)
         .alert("lc.common.error".loc, isPresented: $errorShow){
             Button("lc.common.ok".loc, action: {
             })

--- a/LiveContainerSwiftUI/Views/LCTabView.swift
+++ b/LiveContainerSwiftUI/Views/LCTabView.swift
@@ -25,12 +25,18 @@ struct LCTabView: View {
     @StateObject var downloadHelper = DownloadHelper()
     
     let pub = NotificationCenter.default.publisher(for: UIScene.didDisconnectNotification)
+    
+    private var appListView: LCAppListView {
+        LCAppListView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
+    }
+    
+    private var sourcesView: LCSourcesView {
+        LCSourcesView()
+    }
 
     
     var body: some View {
         Group {
-            let appListView = LCAppListView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
-            let sourcesView = LCSourcesView()
             if #available(iOS 19.0, *), SharedModel.isLiquidGlassSearchEnabled {
                 TabView(selection: $sharedModel.selectedTab) {
                     if DataManager.shared.model.multiLCStatus != 2 {

--- a/LiveProcess/LiveProcess.entitlements
+++ b/LiveProcess/LiveProcess.entitlements
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.healthkit</key>
-	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array>
-		<string>health-records</string>
-	</array>
-	<key>com.apple.developer.healthkit.background-delivery</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_SIDESTORE)</string>

--- a/entitlements.catalyst.xml
+++ b/entitlements.catalyst.xml
@@ -23,14 +23,6 @@
 	<true/>
 	<key>com.apple.developer.team-identifier</key>
 	<string>AAAAA11111</string>
-	<key>com.apple.developer.healthkit</key>
-	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array>
-		<string>health-records</string>
-	</array>
-	<key>com.apple.developer.healthkit.background-delivery</key>
-	<true/>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>AAAAA11111.com.kdt.livecontainer.shared</string>

--- a/entitlements.xml
+++ b/entitlements.xml
@@ -4,14 +4,6 @@
 <dict>
 	<key>application-identifier</key>
 	<string>$(DEVELOPMENT_TEAM).$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>com.apple.developer.healthkit</key>
-	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array>
-		<string>health-records</string>
-	</array>
-	<key>com.apple.developer.healthkit.background-delivery</key>
-	<true/>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>
 	<true/>
 	<key>com.apple.developer.team-identifier</key>

--- a/patch_lctabview.swift
+++ b/patch_lctabview.swift
@@ -1,0 +1,150 @@
+import Foundation
+import SwiftUI
+
+struct LCTabView: View {
+@Binding var appDataFolderNames: [String]
+@Binding var tweakFolderNames: [String]
+
+@State var errorShow = false
+@State var crashReportShow = false
+@State var errorInfo = ""
+
+@State var previousSelectedTab : LCTabIdentifier = .apps
+
+@EnvironmentObject var sharedModel : SharedModel
+@EnvironmentObject var sceneDelegate: SceneDelegate
+@State var shouldToggleMainWindowOpen = false
+@Environment(\.scenePhase) var scenePhase
+@StateObject var downloadHelper = DownloadHelper()
+let pub = NotificationCenter.default.publisher(for: UIScene.didDisconnectNotification)
+
+private var appListView: LCAppListView {
+LCAppListView(appDataFolderNames: $appDataFolderNames, tweakFolderNames: $tweakFolderNames)
+}
+
+private var sourcesView: LCSourcesView {
+LCSourcesView()
+}
+
+var body: some View {
+Group {
+if #available(iOS 19.0, *), SharedModel.isLiquidGlassSearchEnabled {
+TabView(selection: $sharedModel.selectedTab) {
+if DataManager.shared.model.multiLCStatus \!= 2 {
+Tab("lc.tabView.sources".loc, systemImage: "books.vertical", value: LCTabIdentifier.sources) {
+sourcesView
+}
+}
+Tab("lc.tabView.apps".loc, systemImage: "square.stack.3d.up.fill", value: LCTabIdentifier.apps) {
+appListView
+}
+if DataManager.shared.model.multiLCStatus \!= 2 {
+Tab("lc.tabView.tweaks".loc, systemImage: "wrench.and.screwdriver", value: LCTabIdentifier.tweaks) {
+LCTweaksView(tweakFolders: $tweakFolderNames)
+}
+}
+Tab("lc.tabView.settings".loc, systemImage: "gearshape.fill", value: LCTabIdentifier.settings) {
+LCSettingsView(appDataFolderNames: $appDataFolderNames)
+}
+Tab("Search".loc, systemImage: "magnifyingglass", value: LCTabIdentifier.search, role: .search) {
+if previousSelectedTab == .sources {
+sourcesView
+.searchable(text: sourcesView.$searchContext.query)
+} else {
+appListView
+.searchable(text: appListView.$searchContext.query)
+}
+}
+}
+} else {
+TabView(selection: $sharedModel.selectedTab) {
+if DataManager.shared.model.multiLCStatus \!= 2 {
+sourcesView
+.tabItem {
+Label("lc.tabView.sources".loc, systemImage: "books.vertical")
+}
+.tag(LCTabIdentifier.sources)
+}
+appListView
+.tabItem {
+Label("lc.tabView.apps".loc, systemImage: "square.stack.3d.up.fill")
+}
+.tag(LCTabIdentifier.apps)
+if DataManager.shared.model.multiLCStatus \!= 2 {
+LCTweaksView(tweakFolders: $tweakFolderNames)
+.tabItem{
+Label("lc.tabView.tweaks".loc, systemImage: "wrench.and.screwdriver")
+}
+.tag(LCTabIdentifier.tweaks)
+}
+
+LCSettingsView(appDataFolderNames: $appDataFolderNames)
+.tabItem {
+Label("lc.tabView.settings".loc, systemImage: "gearshape.fill")
+}
+.tag(LCTabIdentifier.settings)
+}
+}
+}
+.downloadAlert(helper: downloadHelper)
+.environmentObject(downloadHelper)
+.alert("lc.common.error".loc, isPresented: $errorShow){
+Button("lc.common.ok".loc, action: {
+})
+Button("lc.common.copy".loc, action: {
+copyError()
+})
+} message: {
+Text(errorInfo)
+}
+.sheet(isPresented: $crashReportShow) {
+NavigationView {
+ScrollView {
+Text(errorInfo)
+.font(.system(size: 12).monospaced())
+.fixedSize(horizontal: false, vertical: false)
+.textSelection(.enabled)
+}
+.frame(maxWidth: .infinity)
+.padding(.horizontal)
+.toolbar {
+ToolbarItem(placement: .topBarLeading) {
+Button("lc.common.copy".loc, action: {
+copyError()
+})
+}
+ToolbarItem(placement: .topBarTrailing) {
+Button("lc.common.ok".loc, action: {
+crashReportShow = false
+})
+}
+}
+.navigationTitle("lc.common.error".loc)
+.navigationBarTitleDisplayMode(.inline)
+}
+}
+.task {
+closeDuplicatedWindow()
+checkLastLaunchError()
+checkTeamId()
+checkBundleId()
+checkGetTaskAllow()
+checkPrivateContainerBookmark()
+}
+.onReceive(pub) { out in
+if let scene1 = sceneDelegate.window?.windowScene, let scene2 = out.object as? UIWindowScene, scene1 == scene2 {
+if shouldToggleMainWindowOpen {
+DataManager.shared.model.mainWindowOpened = false
+}
+}
+}
+.onChange(of: sharedModel.selectedTab) { newValue in
+if newValue \!= LCTabIdentifier.search {
+previousSelectedTab = newValue
+}
+}
+.onOpenURL { url in
+dispatchURL(url: url)
+}
+}
+}


### PR DESCRIPTION
## Problem
1. Download fail ("network connection lost") when device sleep or app backgrounded.
2. User can switch tab during download popup, lose dialog.

## Fix
- **Fix network drop:** Swap `URLSessionConfiguration.default` to `.background(withIdentifier:)`. Allow download survive device sleep/background state.
- **Block tab bar:** Move `.downloadAlert` modifier from `LCAppListView` to root `LCTabView`. Inject `DownloadHelper` via `.environmentObject()`. ZStack overlay now cover entire screen, block tab clicks.

* Note: For writing this, I used ai to help me.