### PR TITLE
Update actions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           xcode-version: '26.2'
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Set Scheme
@@ -71,13 +71,13 @@ jobs:
           sh .github/build_github.sh
 
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.scheme }}.ipa
           path: ${{ env.scheme }}.ipa
       
       - name: Upload LiveContainer+SideStore
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.scheme }}+SideStore.ipa
           path: ${{ env.scheme }}+SideStore.ipa
@@ -97,11 +97,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Download a Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build.outputs.artifact }}
       - name: Download a Build Artifact2
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build.outputs.artifact2 }}
       - name: Get Commit Info
@@ -121,7 +121,7 @@ jobs:
         run: |
           python .github/update_json.py
       - name: Nightly Release
-        uses: andelf/nightly-release@v1
+        uses: andelf/nightly-release@v5834076edc55cc05975561c9722043f072ac5c26
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with: 
@@ -135,7 +135,7 @@ jobs:
             ${{ needs.build.outputs.artifact2 }}
             .github/apps_nightly.json
       - name: Update apps.json in Release 1.0
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "1.0"
           files: |

--- a/.github/workflows/update_source.yml
+++ b/.github/workflows/update_source.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -46,7 +46,7 @@ jobs:
         python .github/update_json.py
 
     - name: Update apps.json in Release 1.0
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: "1.0"
         files: |


### PR DESCRIPTION
Update github actions to latest versions to avoid https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

For andelf/nightly-release i updated to latest comment (which adds node 24 support) because a new release has not been created.