### PR TITLE
Re-implement JIT acquisition on apps running in multitask

### DIFF
--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -220,6 +220,11 @@ class LCAppModel: ObservableObject, Hashable {
             uiSelectedContainer = uiContainers.first { $0.folderName == containerFolderName } ?? uiSelectedContainer
         }
         let currentDataFolder = containerFolderName ?? uiSelectedContainer?.folderName
+        var is32bit = false
+        
+        #if is32BitSupported
+        is32bit = appInfo.is32bit
+        #endif
         
         var shouldMultitask = multitask ?? shouldLaunchInMultitaskMode
         let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType"))
@@ -283,11 +288,6 @@ class LCAppModel: ObservableObject, Hashable {
         
 
         UserDefaults.standard.set(uiSelectedContainer?.folderName, forKey: "selectedContainer")
-        var is32bit = false
-        
-        #if is32BitSupported
-        is32bit = appInfo.is32bit
-        #endif
         var jitNeeded = appInfo.isJITNeeded
         if let forceJIT {
             jitNeeded = forceJIT

--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -221,9 +221,14 @@ class LCAppModel: ObservableObject, Hashable {
         }
         let currentDataFolder = containerFolderName ?? uiSelectedContainer?.folderName
         
-        let multitask = multitask ?? shouldLaunchInMultitaskMode;
+        var shouldMultitask = multitask ?? shouldLaunchInMultitaskMode
+        let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType"))
+        let supportsPIDJIT = jitEnabler == .StikJIT || jitEnabler == .StikJITLC || jitEnabler == .StosDebug || jitEnabler == .StosDebugLC
+        if (appInfo.isJITNeeded || is32bit) && !supportsPIDJIT {
+            shouldMultitask = false
+        }
         
-        if multitask,
+        if shouldMultitask,
            let currentDataFolder,
            await bringExistingMultitaskWindowIfNeeded(dataUUID: currentDataFolder) {
             return
@@ -249,7 +254,7 @@ class LCAppModel: ObservableObject, Hashable {
         }
         
         // ask user if they want to terminate all multitasking apps
-        if MultitaskManager.isMultitasking() && !multitask {
+        if MultitaskManager.isMultitasking() && !shouldMultitask {
             if let currentDataFolder,
                await bringExistingMultitaskWindowIfNeeded(dataUUID: currentDataFolder) {
                 return
@@ -288,7 +293,7 @@ class LCAppModel: ObservableObject, Hashable {
             jitNeeded = forceJIT
         }
         if jitNeeded || is32bit {
-            if multitask, #available(iOS 17.4, *) {
+            if shouldMultitask, #available(iOS 17.4, *) {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                     LCUtils.launchMultitaskGuestApp(appInfo.displayName()) { pidNumber, error in
                         if let error {
@@ -317,7 +322,7 @@ class LCAppModel: ObservableObject, Hashable {
                     await delegate?.jitLaunch(appName: self.appInfo.displayName())
                 }
             }
-        } else if multitask, #available(iOS 16.0, *) {
+        } else if shouldMultitask, #available(iOS 16.0, *) {
             try await LCUtils.launchMultitaskGuestApp(appInfo.displayName())
         } else {
             if #available(iOS 26.0, *), FileManager.default.fileExists(atPath: "\(appInfo.bundlePath()!)/Frameworks/MetalANGLE.framework/MetalANGLE") {

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -418,13 +418,19 @@ extension LCUtils {
                     return false
                 }
                 // check if stosdebug is already running
+                let currentScheme = LCUtils.appUrlScheme()?.lowercased()
                 var freeScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
+                if freeScheme?.lowercased() == currentScheme {
+                    freeScheme = nil
+                }
                 
                 if(freeScheme == nil) {
                     // if not, try to find a free lc
                     forEachInstalledLC(isFree: true) { scheme, shouldBreak in
-                        freeScheme = scheme
-                        shouldBreak = true
+                        if scheme.lowercased() != currentScheme {
+                            freeScheme = scheme
+                            shouldBreak = true
+                        }
                     }
                 }
                 guard let freeScheme else {
@@ -434,7 +440,7 @@ extension LCUtils {
                 
                 let launchURL = URL(string: "\(freeScheme)://open-url?url=\(encodedStr)")!
                 
-                LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath, forKey: "LCLaunchExtensionBundleID")
+                LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath ?? appToLaunch.bundleIdentifier, forKey: "LCLaunchExtensionBundleID")
                 LCUtils.appGroupUserDefault.set(Date.now, forKey: "LCLaunchExtensionLaunchDate")
                 onServerMessage?("JIT acquisition will continue in another LiveContainer.")
                 
@@ -479,13 +485,19 @@ extension LCUtils {
                     return false
                 }
                 // check if stikdebug is already running
+                let currentScheme = LCUtils.appUrlScheme()?.lowercased()
                 var freeScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
+                if freeScheme?.lowercased() == currentScheme {
+                    freeScheme = nil
+                }
                 
                 if(freeScheme == nil) {
                     // if not, try to find a free lc
                     forEachInstalledLC(isFree: true) { scheme, shouldBreak in
-                        freeScheme = scheme
-                        shouldBreak = true
+                        if scheme.lowercased() != currentScheme {
+                            freeScheme = scheme
+                            shouldBreak = true
+                        }
                     }
                 }
                 guard let freeScheme else {
@@ -495,7 +507,7 @@ extension LCUtils {
                 
                 launchURL = URL(string: "\(freeScheme)://open-url?url=\(encodedStr)")!
                 
-                LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath, forKey: "LCLaunchExtensionBundleID")
+                LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath ?? appToLaunch.bundleIdentifier, forKey: "LCLaunchExtensionBundleID")
                 LCUtils.appGroupUserDefault.set(Date.now, forKey: "LCLaunchExtensionLaunchDate")
                 onServerMessage?("JIT acquisition will continue in another LiveContainer.")
                 

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -388,7 +388,7 @@ extension LCUtils {
             var launchURLStr = "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)"
             
             if let script = script, !script.isEmpty {
-                launchURLStr += "&script=\(script)"
+                launchURLStr += "&scriptData=\(script)"
             }
             
             if jitEnabler == .StosDebugLC {

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -388,7 +388,7 @@ extension LCUtils {
             var launchURLStr = "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)"
             
             if let script = script, !script.isEmpty {
-                launchURLStr += "&scriptData=\(script)"
+                launchURLStr += "&script=\(script)"
             }
             
             if jitEnabler == .StosDebugLC {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1083,6 +1083,18 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         appToLaunch.appInfo.relativeBundlePath ?? appToLaunch.bundleIdentifier
     }
 
+    private func targetGuestBundleIdForPIDJIT() -> String {
+        if let selectedBundlePath = UserDefaults.standard.string(forKey: "selected") {
+            let appListsToConsider: [[LCAppModel]] = [sharedModel.apps, sharedModel.hiddenApps]
+            for appList in appListsToConsider {
+                if let app = appList.first(where: { $0.appInfo.relativeBundlePath == selectedBundlePath }) {
+                    return app.bundleIdentifier
+                }
+            }
+        }
+        return Bundle.main.bundleIdentifier ?? ""
+    }
+
     private func multitaskPIDJITRelayScheme(for appToLaunch: LCAppModel) -> String? {
         let currentScheme = LCUtils.appUrlScheme()?.lowercased()
         let runningScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
@@ -1142,7 +1154,8 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return
                         }
                     } else {
-                        if let url = URL(string: "stosdebug://enableJIT?appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)") {
+                        let targetBundleId = targetGuestBundleIdForPIDJIT()
+                        if let url = URL(string: "stosdebug://enableJIT?bundleId=\(targetBundleId)&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)") {
                             UIApplication.shared.open(url)
                         }
                     }

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1142,7 +1142,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return
                         }
                     } else {
-                        if let url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)") {
+                        if let url = URL(string: "stosdebug://enableJIT?appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)") {
                             UIApplication.shared.open(url)
                         }
                     }

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1078,15 +1078,31 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
         LCSharedUtils.launchToGuestApp()
 
     }
-    
-    private func openJITInAnotherLC(encodedURL: String, appToLaunch: LCAppModel, errorMessage: String) async -> Bool {
-        var freeScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
-        if freeScheme == nil {
-            LCUtils.forEachInstalledLC(isFree: true) { scheme, shouldBreak in
+
+    private func multitaskPIDJITBundleId(for appToLaunch: LCAppModel) -> String {
+        appToLaunch.appInfo.relativeBundlePath ?? appToLaunch.bundleIdentifier
+    }
+
+    private func multitaskPIDJITRelayScheme(for appToLaunch: LCAppModel) -> String? {
+        let currentScheme = LCUtils.appUrlScheme()?.lowercased()
+        let runningScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
+        if let runningScheme,
+           runningScheme.lowercased() != currentScheme {
+            return runningScheme
+        }
+
+        var freeScheme: String?
+        LCUtils.forEachInstalledLC(isFree: true) { scheme, shouldBreak in
+            if scheme.lowercased() != currentScheme {
                 freeScheme = scheme
                 shouldBreak = true
             }
         }
+        return freeScheme
+    }
+    
+    private func openJITInAnotherLC(encodedURL: String, appToLaunch: LCAppModel, errorMessage: String) async -> Bool {
+        let freeScheme = multitaskPIDJITRelayScheme(for: appToLaunch)
         guard let freeScheme else {
             errorInfo = errorMessage
             errorShow = true
@@ -1099,7 +1115,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             return false
         }
 
-        LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath, forKey: "LCLaunchExtensionBundleID")
+        LCUtils.appGroupUserDefault.set(multitaskPIDJITBundleId(for: appToLaunch), forKey: "LCLaunchExtensionBundleID")
         LCUtils.appGroupUserDefault.set(Date.now, forKey: "LCLaunchExtensionLaunchDate")
         await UIApplication.shared.open(launchURL)
         return true
@@ -1117,7 +1133,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return app.appInfo.urlSchemes().contains("stosdebug") &&
                             (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
                         }) {
-                            let urlString = "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)"
+                            let urlString = "stosdebug://enableJIT?bundleId=\(multitaskPIDJITBundleId(for: app))&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)"
                             let encodedStr = Data(urlString.utf8).base64EncodedString().addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
                             Task { _ = await openJITInAnotherLC(encodedURL: encodedStr, appToLaunch: app, errorMessage: "No free LiveContainer is available. Please either: \n(1)close one, \n(2)install a new one, \n(3)choose another method to enable JIT.") }
                         } else {
@@ -1126,7 +1142,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return
                         }
                     } else {
-                        if let url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&forcePID=true\(encoded)") {
+                        if let url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)") {
                             UIApplication.shared.open(url)
                         }
                     }
@@ -1134,23 +1150,21 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                 }
 
                 let encoded = encodedData.map { "&script-data=\($0)" } ?? ""
-                if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)&pid=\(pid)\(encoded)") {
-                    if jitEnabler == .StikJITLC {
-                        if let app = sharedModel.apps.first(where: { app in
-                            return app.appInfo.urlSchemes().contains("stikjit") &&
-                            (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
-                        }) {
-                            let urlString = url.absoluteString
-                            let encodedStr = Data(urlString.utf8).base64EncodedString().addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
-                            Task { _ = await openJITInAnotherLC(encodedURL: encodedStr, appToLaunch: app, errorMessage: "No free LiveContainer is available. Please either: \n(1)close one, \n(2)install a new one, \n(3)choose another method to enable JIT.") }
-                        } else {
-                            errorInfo = "StikDebug is not found. Please install it first and switch it to shared app."
-                            errorShow = true
-                            return
-                        }
+                if jitEnabler == .StikJITLC {
+                    if let app = sharedModel.apps.first(where: { app in
+                        return app.appInfo.urlSchemes().contains("stikjit") &&
+                        (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
+                    }) {
+                        let urlString = "stikjit://enable-jit?bundle-id=\(multitaskPIDJITBundleId(for: app))&pid=\(pid)\(encoded)"
+                        let encodedStr = Data(urlString.utf8).base64EncodedString().addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
+                        Task { _ = await openJITInAnotherLC(encodedURL: encodedStr, appToLaunch: app, errorMessage: "No free LiveContainer is available. Please either: \n(1)close one, \n(2)install a new one, \n(3)choose another method to enable JIT.") }
                     } else {
-                        UIApplication.shared.open(url)
+                        errorInfo = "StikDebug is not found. Please install it first and switch it to shared app."
+                        errorShow = true
+                        return
                     }
+                } else if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)&pid=\(pid)\(encoded)") {
+                    UIApplication.shared.open(url)
                 }
             }
         }

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1127,7 +1127,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
 
             if let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")) {
                 if jitEnabler == .StosDebug || jitEnabler == .StosDebugLC {
-                    let encoded = encodedData.map { "&script=\($0)" } ?? ""
+                    let encoded = encodedData.map { "&scriptData=\($0)" } ?? ""
                     if jitEnabler == .StosDebugLC {
                         if let app = sharedModel.apps.first(where: { app in
                             return app.appInfo.urlSchemes().contains("stosdebug") &&

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1079,11 +1079,36 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
 
     }
     
+    private func openJITInAnotherLC(encodedURL: String, appToLaunch: LCAppModel, errorMessage: String) async -> Bool {
+        var freeScheme = LCSharedUtils.getContainerUsingLCScheme(withFolderName: appToLaunch.uiDefaultDataFolder)
+        if freeScheme == nil {
+            LCUtils.forEachInstalledLC(isFree: true) { scheme, shouldBreak in
+                freeScheme = scheme
+                shouldBreak = true
+            }
+        }
+        guard let freeScheme else {
+            errorInfo = errorMessage
+            errorShow = true
+            return false
+        }
+
+        guard let launchURL = URL(string: "\(freeScheme)://open-url?url=\(encodedURL)") else {
+            errorInfo = "lc.appList.urlInvalidError".loc
+            errorShow = true
+            return false
+        }
+
+        LCUtils.appGroupUserDefault.set(appToLaunch.appInfo.relativeBundlePath, forKey: "LCLaunchExtensionBundleID")
+        LCUtils.appGroupUserDefault.set(Date.now, forKey: "LCLaunchExtensionLaunchDate")
+        await UIApplication.shared.open(launchURL)
+        return true
+    }
+
     func jitLaunch(withPID pid: Int, withScript script: String? = nil, appName: String) async {
         await MainActor.run {
             let encodedData = script?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-                
-            
+
             if let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")) {
                 if jitEnabler == .StosDebug || jitEnabler == .StosDebugLC {
                     let encoded = encodedData.map { "&script=\($0)" } ?? ""
@@ -1092,22 +1117,22 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return app.appInfo.urlSchemes().contains("stosdebug") &&
                             (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
                         }) {
-                            if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false& forcePID=true\(encoded)") {
-                                Task { await openWebView(urlString: url.absoluteString) }
-                            }
+                            let urlString = "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)"
+                            let encodedStr = Data(urlString.utf8).base64EncodedString().addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
+                            Task { _ = await openJITInAnotherLC(encodedURL: encodedStr, appToLaunch: app, errorMessage: "No free LiveContainer is available. Please either: \n(1)close one, \n(2)install a new one, \n(3)choose another method to enable JIT.") }
                         } else {
                             errorInfo = "StosDebug is not found. Please install it first and switch it to shared app."
                             errorShow = true
                             return
                         }
                     } else {
-                        if var url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&forcePID=true\(encoded)") {
+                        if let url = URL(string: "stosdebug://enableJIT?bundleId=\(Bundle.main.bundleIdentifier!)&appName=\(appName)&pid=\(pid)&forcePID=true\(encoded)") {
                             UIApplication.shared.open(url)
                         }
                     }
                     return
                 }
-                
+
                 let encoded = encodedData.map { "&script-data=\($0)" } ?? ""
                 if let url = URL(string: "stikjit://enable-jit?bundle-id=\(Bundle.main.bundleIdentifier!)&pid=\(pid)\(encoded)") {
                     if jitEnabler == .StikJITLC {
@@ -1115,7 +1140,9 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return app.appInfo.urlSchemes().contains("stikjit") &&
                             (sharedModel.multiLCStatus != 2 || app.appInfo.isShared)
                         }) {
-                            Task { await openWebView(urlString: url.absoluteString) }
+                            let urlString = url.absoluteString
+                            let encodedStr = Data(urlString.utf8).base64EncodedString().addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? ""
+                            Task { _ = await openJITInAnotherLC(encodedURL: encodedStr, appToLaunch: app, errorMessage: "No free LiveContainer is available. Please either: \n(1)close one, \n(2)install a new one, \n(3)choose another method to enable JIT.") }
                         } else {
                             errorInfo = "StikDebug is not found. Please install it first and switch it to shared app."
                             errorShow = true

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -1139,7 +1139,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
 
             if let jitEnabler = JITEnablerType(rawValue: LCUtils.appGroupUserDefault.integer(forKey: "LCJITEnablerType")) {
                 if jitEnabler == .StosDebug || jitEnabler == .StosDebugLC {
-                    let encoded = encodedData.map { "&scriptData=\($0)" } ?? ""
+                    let encoded = encodedData.map { "&script=\($0)" } ?? ""
                     if jitEnabler == .StosDebugLC {
                         if let app = sharedModel.apps.first(where: { app in
                             return app.appInfo.urlSchemes().contains("stosdebug") &&
@@ -1154,8 +1154,13 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                             return
                         }
                     } else {
-                        let targetBundleId = targetGuestBundleIdForPIDJIT()
-                        if let url = URL(string: "stosdebug://enableJIT?bundleId=\(targetBundleId)&appName=\(appName)&pid=\(pid)&relaunchApp=false&forcePID=true\(encoded)") {
+                        let targetBundleId = UserDefaults.standard.string(forKey: "selected") ?? targetGuestBundleIdForPIDJIT()
+                        let encodedAppName = appName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? appName
+                        var urlString = "stosdebug://enableJIT?bundleId=\(targetBundleId)&appName=\(encodedAppName)&pid=\(pid)&relaunchApp=false&forcePID=true"
+                        if let encodedData, !encodedData.isEmpty {
+                            urlString += "&script=\(encodedData)"
+                        }
+                        if let url = URL(string: urlString) {
                             UIApplication.shared.open(url)
                         }
                     }


### PR DESCRIPTION
This PR makes JIT acquire correctly for apps running in multitask, both using StikDebug and StosDebug, and for native/virtual windows, on both TXM and non-TXM devices. Tested on non-TXM iPad (9th gen) and TXM iPhone (17 pro) with UTM. No way to make either StosDebug or StikDebug redirect back to LiveContainer, but once launched, you can swipe back to LiveContainer or the spawned native window process (on iPad) to continue using the app with JIT acquired.