### PR TITLE
Show open state for installed source apps

### DIFF
--- a/LiveContainerSwiftUI/Utilities/LCSourceAppInstallState.swift
+++ b/LiveContainerSwiftUI/Utilities/LCSourceAppInstallState.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct SourceAppInstalledApp: Equatable {
+    let bundleIdentifier: String
+    let version: String
+    let relativeBundlePath: String
+}
+
+enum SourceAppInstallState: Equatable {
+    case install
+    case run(relativeBundlePath: String)
+}
+
+enum SourceAppInstallStateResolver {
+    static func state(
+        forSourceBundleIdentifier bundleIdentifier: String,
+        latestVersion: String?,
+        installedApps: [SourceAppInstalledApp]
+    ) -> SourceAppInstallState {
+        guard let latestVersion = latestVersion?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !latestVersion.isEmpty else {
+            return .install
+        }
+
+        guard let installedApp = installedApps.first(where: { $0.bundleIdentifier == bundleIdentifier }) else {
+            return .install
+        }
+
+        if installedApp.version.trimmingCharacters(in: .whitespacesAndNewlines) == latestVersion {
+            return .run(relativeBundlePath: installedApp.relativeBundlePath)
+        }
+
+        return .install
+    }
+}

--- a/LiveContainerSwiftUI/Utilities/LCSourceAppInstallState.swift
+++ b/LiveContainerSwiftUI/Utilities/LCSourceAppInstallState.swift
@@ -22,14 +22,17 @@ enum SourceAppInstallStateResolver {
             return .install
         }
 
-        guard let installedApp = installedApps.first(where: { $0.bundleIdentifier == bundleIdentifier }) else {
-            return .install
+        // LiveContainer supports installing multiple copies with the same bundle ID.
+        // Only switch to Run when one of those copies is already at the source's latest version.
+        for installedApp in installedApps where installedApp.bundleIdentifier == bundleIdentifier {
+            let installedVersion = installedApp.version.trimmingCharacters(in: .whitespacesAndNewlines)
+            if installedVersion == latestVersion {
+                return .run(relativeBundlePath: installedApp.relativeBundlePath)
+            }
         }
 
-        if installedApp.version.trimmingCharacters(in: .whitespacesAndNewlines) == latestVersion {
-            return .run(relativeBundlePath: installedApp.relativeBundlePath)
-        }
-
+        // Keep Install available for different versions so users can add another copy
+        // or choose the existing replace flow themselves.
         return .install
     }
 }

--- a/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
+++ b/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
@@ -517,7 +517,9 @@ struct LCSourcesView: View {
                                     isFiltering: isFiltering,
                                     isExpanded: expandedSources.contains(item.id),
                                     onRefresh: { Task { await viewModel.refreshSource(item) } },
+                                    installState: installState(for:),
                                     onInstall: install(app:),
+                                    onRun: runInstalledApp(relativeBundlePath:),
                                     onRemove: { sourcePendingRemoval = item },
                                     toggleExpanded: { toggleExpansion(for: item.id) }
                                 )
@@ -643,6 +645,26 @@ struct LCSourcesView: View {
             partialResult + filteredApps(for: item).count
         }
     }
+
+    private var installedSourceApps: [SourceAppInstalledApp] {
+        var apps = sharedModel.apps
+        if sharedModel.isHiddenAppUnlocked {
+            apps.append(contentsOf: sharedModel.hiddenApps)
+        }
+
+        return apps.compactMap { app in
+            guard let bundleIdentifier = app.appInfo.bundleIdentifier(),
+                  let relativeBundlePath = app.appInfo.relativeBundlePath else {
+                return nil
+            }
+
+            return SourceAppInstalledApp(
+                bundleIdentifier: bundleIdentifier,
+                version: app.appInfo.version(),
+                relativeBundlePath: relativeBundlePath
+            )
+        }
+    }
     
     private func filteredApps(for item: AltStoreSourcesViewModel.SourceItem) -> [AltStoreSourceApp] {
         guard let source = item.source else { return [] }
@@ -666,6 +688,14 @@ struct LCSourcesView: View {
             }
             return false
         }
+    }
+
+    private func installState(for app: AltStoreSourceApp) -> SourceAppInstallState {
+        SourceAppInstallStateResolver.state(
+            forSourceBundleIdentifier: app.bundleIdentifier,
+            latestVersion: app.latestVersion?.version,
+            installedApps: installedSourceApps
+        )
     }
     
     @MainActor
@@ -694,6 +724,27 @@ struct LCSourcesView: View {
         }
 
 
+    }
+
+    @MainActor
+    private func runInstalledApp(relativeBundlePath: String) {
+        var components = URLComponents()
+        components.scheme = "livecontainer"
+        components.host = "livecontainer-launch"
+        components.queryItems = [
+            URLQueryItem(name: "bundle-name", value: relativeBundlePath)
+        ]
+
+        guard let launchURL = components.url else {
+            return
+        }
+
+        withAnimation {
+            sharedModel.selectedTab = .apps
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            sharedModel.deepLink = launchURL
+        }
     }
     
     private func toggleExpansion(for id: URL) {
@@ -861,7 +912,9 @@ private struct AltStoreSourceSectionView: View {
     let isFiltering: Bool
     let isExpanded: Bool
     let onRefresh: () -> Void
+    let installState: (AltStoreSourceApp) -> SourceAppInstallState
     let onInstall: (AltStoreSourceApp) -> Void
+    let onRun: (String) -> Void
     let onRemove: () -> Void
     let toggleExpanded: () -> Void
     
@@ -924,7 +977,13 @@ private struct AltStoreSourceSectionView: View {
             } else if let source = item.source, isExpanded || isFiltering {
                 VStack(spacing: 12) {
                     ForEach(filteredApps[0..<min(50, filteredApps.count)]) { app in
-                        LCSourceAppBanner(app: app, source: source, installAction: onInstall)
+                        LCSourceAppBanner(
+                            app: app,
+                            source: source,
+                            installState: installState(app),
+                            installAction: onInstall,
+                            runAction: onRun
+                        )
                     }
                     if filteredApps.isEmpty {
                         if source.apps.isEmpty || isFiltering {
@@ -951,7 +1010,9 @@ private struct AltStoreSourceSectionView: View {
 private struct LCSourceAppBanner: View {
     let app: AltStoreSourceApp
     let source: AltStoreSource
+    let installState: SourceAppInstallState
     let installAction: (AltStoreSourceApp) -> Void
+    let runAction: (String) -> Void
     
     @AppStorage("dynamicColors") private var dynamicColors = true
     @Environment(\.colorScheme) var colorScheme
@@ -990,6 +1051,15 @@ private struct LCSourceAppBanner: View {
         }
         return ""
     }
+
+    private var actionTitle: String {
+        switch installState {
+        case .install:
+            return "lc.common.install".loc
+        case .run:
+            return "lc.appBanner.run".loc
+        }
+    }
     
     var body: some View {
         HStack {
@@ -1025,9 +1095,14 @@ private struct LCSourceAppBanner: View {
             .allowsHitTesting(false)
             Spacer()
             Button {
-                installAction(app)
+                switch installState {
+                case .install:
+                    installAction(app)
+                case .run(let relativeBundlePath):
+                    runAction(relativeBundlePath)
+                }
             } label: {
-                Text("lc.common.install".loc)
+                Text(actionTitle)
                     .bold()
                     .foregroundColor(.white)
                     .lineLimit(1)

--- a/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
+++ b/LiveContainerSwiftUI/Views/LCAltStoreSourcesView.swift
@@ -652,6 +652,8 @@ struct LCSourcesView: View {
             apps.append(contentsOf: sharedModel.hiddenApps)
         }
 
+        // Build a lightweight snapshot from every visible install so sources can
+        // distinguish "already installed at latest version" from "install another copy".
         return apps.compactMap { app in
             guard let bundleIdentifier = app.appInfo.bundleIdentifier(),
                   let relativeBundlePath = app.appInfo.relativeBundlePath else {

--- a/Tests/SourceAppInstallationState/main.swift
+++ b/Tests/SourceAppInstallationState/main.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+let installedApps = [
+    SourceAppInstalledApp(
+        bundleIdentifier: "com.example.demo",
+        version: "1.2.3",
+        relativeBundlePath: "com.example.demo.app"
+    )
+]
+
+let matchingState = SourceAppInstallStateResolver.state(
+    forSourceBundleIdentifier: "com.example.demo",
+    latestVersion: "1.2.3",
+    installedApps: installedApps
+)
+expect(
+    matchingState == .run(relativeBundlePath: "com.example.demo.app"),
+    "matching installed source app should run the installed app"
+)
+
+let newerSourceState = SourceAppInstallStateResolver.state(
+    forSourceBundleIdentifier: "com.example.demo",
+    latestVersion: "1.2.4",
+    installedApps: installedApps
+)
+expect(
+    newerSourceState == .install,
+    "different source version should keep the install action available"
+)
+
+let missingState = SourceAppInstallStateResolver.state(
+    forSourceBundleIdentifier: "com.example.missing",
+    latestVersion: "1.0",
+    installedApps: installedApps
+)
+expect(
+    missingState == .install,
+    "missing installed app should offer install"
+)
+
+print("SourceAppInstallationStateTests passed")

--- a/Tests/SourceAppInstallationState/main.swift
+++ b/Tests/SourceAppInstallationState/main.swift
@@ -45,4 +45,27 @@ expect(
     "missing installed app should offer install"
 )
 
+let multiVersionInstalledApps = [
+    SourceAppInstalledApp(
+        bundleIdentifier: "com.example.demo",
+        version: "1.2.2",
+        relativeBundlePath: "com.example.demo-older.app"
+    ),
+    SourceAppInstalledApp(
+        bundleIdentifier: "com.example.demo",
+        version: "1.2.3",
+        relativeBundlePath: "com.example.demo-latest.app"
+    )
+]
+
+let multiVersionState = SourceAppInstallStateResolver.state(
+    forSourceBundleIdentifier: "com.example.demo",
+    latestVersion: "1.2.3",
+    installedApps: multiVersionInstalledApps
+)
+expect(
+    multiVersionState == .run(relativeBundlePath: "com.example.demo-latest.app"),
+    "multi-version installs should run the installed app that matches the latest source version"
+)
+
 print("SourceAppInstallationStateTests passed")


### PR DESCRIPTION
## Summary
- Detect installed source apps by bundle identifier and latest source version, then show `Run` instead of `Install` when the matching version is already installed.
- Preserve LiveContainer's multi-version behavior for apps with the same bundle ID: if only a different version is installed, the source row still shows `Install` so users can install another copy or use the existing replace flow.
- Route the `Run` action through the existing Apps tab launch flow.

## Testing
- `swiftc LiveContainerSwiftUI/Utilities/LCSourceAppInstallState.swift Tests/SourceAppInstallationState/main.swift -o /tmp/source_app_installation_state_tests && /tmp/source_app_installation_state_tests`
- `git diff --cached --check`
- `xcodebuild -project LiveContainer.xcodeproj -scheme LiveContainerSwiftUI -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO ARCHS=arm64 ONLY_ACTIVE_ARCH=YES`