### PR TITLE
Fix iOS 27 Beta 1 Compatibility (Dynamic _MergedGlobals offset & CFBundle patch fallback) 

### DIFF
--- a/.github/build_github.sh
+++ b/.github/build_github.sh
@@ -1,13 +1,17 @@
-# copy lc
-wget https://github.com/LiveContainer/SideStore/releases/download/dylibify/dylibify
+set -eu
+
+rm -rf Payload tmp .zsign_cache dylibify "$scheme.ipa" "$scheme+SideStore.ipa"
+
+# compile local patcher
+clang -o dylibify .github/sidelc/lc_dylibify.c
 chmod +x dylibify
 brew install ldid
 
-# move lc to working folder
-mv "$archive_path.xcarchive/Products/Applications" Payload
+# copy lc to working folder
+cp -R "$archive_path.xcarchive/Products/Applications" Payload
 
 # temporarily move sidestore support framrwork to tmp before zip
-mkdir tmp
+mkdir -p tmp
 mv Payload/LiveContainer.app/Frameworks/SideStore.framework ./tmp
 
 zip -r "$scheme.ipa" "Payload" -x "._*" -x ".DS_Store" -x "__MACOSX"
@@ -47,9 +51,7 @@ cd ..
 
 # SideStore
 mv ./tmp/Payload/SideStore.app ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework
-./dylibify ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore.dylib
-rm ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore
-mv ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore.dylib ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore
+./dylibify ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore
 ldid -S"" ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/SideStore
 cp ./.github/sidelc/LCAppInfo.plist ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/
 
@@ -66,8 +68,10 @@ cp -r ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/Frameworks .
 mv ./Payload/LiveContainer.app/PlugIns/LiveWidgetExtension.appex/AltWidgetExtension ./Payload/LiveContainer.app/PlugIns/LiveWidgetExtension.appex/LiveWidgetExtension
 
 # Sign
-rm -r .zsign_cache
-find payloadlc/Payload -type d -name "_CodeSignature" -exec rm -r {} +
+rm -rf .zsign_cache
+if [ -d payloadlc/Payload ]; then
+    find payloadlc/Payload -type d -name "_CodeSignature" -exec rm -r {} +
+fi
 
 ldid -S.github/sidelc/LiveWidgetExtension_adhoc.xml ./Payload/LiveContainer.app/PlugIns/LiveWidgetExtension.appex/LiveWidgetExtension
 

--- a/.github/sidelc/lc_dylibify.c
+++ b/.github/sidelc/lc_dylibify.c
@@ -1,0 +1,135 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <mach-o/loader.h>
+#include <mach-o/fat.h>
+#include <libgen.h>
+#include <unistd.h>
+#include <stdbool.h>
+
+static uint32_t rnd32(uint32_t v, uint32_t r) {
+    r--;
+    return (v + r) & ~r;
+}
+
+static void insertDylibCommand(uint32_t cmd, const char *path, struct mach_header_64 *header) {
+    const char *name = cmd==LC_ID_DYLIB ? basename((char *)path) : path;
+    struct dylib_command *dylib;
+    size_t cmdsize = sizeof(struct dylib_command) + rnd32((uint32_t)strlen(name) + 1, 8);
+    if (cmd == LC_ID_DYLIB) {
+        dylib = (struct dylib_command *)(sizeof(struct mach_header_64) + (uintptr_t)header);
+        memmove((void *)((uintptr_t)dylib + cmdsize), (void *)dylib, header->sizeofcmds);
+        bzero(dylib, cmdsize);
+    } else {
+        dylib = (struct dylib_command *)(sizeof(struct mach_header_64) + (void *)header+header->sizeofcmds);
+    }
+    dylib->cmd = cmd;
+    dylib->cmdsize = cmdsize;
+    dylib->dylib.name.offset = sizeof(struct dylib_command);
+    dylib->dylib.compatibility_version = 0x10000;
+    dylib->dylib.current_version = 0x10000;
+    dylib->dylib.timestamp = 2;
+    strncpy((void *)dylib + dylib->dylib.name.offset, name, strlen(name));
+    header->ncmds++;
+    header->sizeofcmds += dylib->cmdsize;
+}
+
+static void replaceDylinkerWithIDDylibCommand(struct dylinker_command* dylinkerCommand, const char *path) {
+    uint32_t size = dylinkerCommand->cmdsize;
+    struct dylib_command* newDylibCommand = (struct dylib_command*)dylinkerCommand;
+    newDylibCommand->cmd = LC_ID_DYLIB;
+    newDylibCommand->dylib.name.offset = sizeof(struct dylib_command);
+    newDylibCommand->dylib.compatibility_version = 0x10000;
+    newDylibCommand->dylib.current_version = 0x10000;
+    newDylibCommand->dylib.timestamp = 2;
+    uint32_t nameSize = size - sizeof(struct dylib_command);
+    const char* name = basename((char *)path);
+    strncpy((void *)newDylibCommand + newDylibCommand->dylib.name.offset, name, nameSize);
+    *((char *)newDylibCommand + newDylibCommand->dylib.name.offset + nameSize - 1) = 0;
+}
+
+int LCPatchExecSlice(const char *path, struct mach_header_64 *header) {
+    uint8_t *imageHeaderPtr = (uint8_t*)header + sizeof(struct mach_header_64);
+    if (header->magic == MH_MAGIC_64) {
+        header->filetype = MH_DYLIB;
+        header->flags |= MH_NO_REEXPORTED_DYLIBS;
+        header->flags &= ~MH_PIE;
+    }
+    struct segment_command_64 *seg = (struct segment_command_64 *)imageHeaderPtr;
+    if (seg->cmd == LC_SEGMENT_64 && seg->vmaddr == 0) {
+        seg->vmaddr = 0x100000000 - 0x4000;
+        seg->vmsize = 0x4000;
+        strncpy(seg->segname, "__PAGEZER0", 16);
+    }
+
+    bool hasDylibCommand = false;
+    int textSectionOffest = 0;
+    struct load_command *command = (struct load_command *)imageHeaderPtr;
+    struct dylinker_command* dylinkerCommand = 0;
+    bool codeSignatureCommandFound = false;
+    for(int i = 0; i < header->ncmds; i++) {
+        if(command->cmd == LC_ID_DYLIB) {
+            hasDylibCommand = true;
+        } else if(command->cmd == LC_SEGMENT_64) {
+            struct segment_command_64* seglc = (struct segment_command_64*)command;
+            if (strcmp("__TEXT", seglc->segname) == 0) {
+                for (uint32_t j = 0; j < seglc->nsects; j++) {
+                    struct section_64* sect = (struct section_64*)(((void*)command + sizeof(struct segment_command_64) + sizeof(struct section_64) * j));
+                    if (0 == strcmp("__text", sect->sectname)) {
+                        textSectionOffest = sect->offset;
+                    }
+                }
+            }
+        } else if (command->cmd == LC_CODE_SIGNATURE) {
+            codeSignatureCommandFound = true;
+        } else if (command->cmd == LC_LOAD_DYLINKER) {
+            dylinkerCommand = (struct dylinker_command*)command;
+        }
+        command = (struct load_command *)((void *)command + command->cmdsize);
+    }
+    long freeLoadCommandCountLeft = (void*)header + textSectionOffest - (void*)command;
+    if(!codeSignatureCommandFound) freeLoadCommandCountLeft -= 0x10;
+
+    int idDylibCommandSize = sizeof(struct dylib_command) + rnd32((uint32_t)strlen(basename((char*)path)) + 1, 8);
+    if(!hasDylibCommand) {
+        if (freeLoadCommandCountLeft >= idDylibCommandSize) {
+            freeLoadCommandCountLeft -= idDylibCommandSize;
+            insertDylibCommand(LC_ID_DYLIB, path, header);
+        } else if (dylinkerCommand) {
+            replaceDylinkerWithIDDylibCommand(dylinkerCommand, path);
+        }
+    }
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    if(argc < 2) return 1;
+    const char *path = argv[1];
+    int fd = open(path, O_RDWR, 0600);
+    if(fd < 0) return 1;
+    struct stat s;
+    fstat(fd, &s);
+    void *map = mmap(NULL, s.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (map == MAP_FAILED) return 1;
+    uint32_t magic = *(uint32_t *)map;
+    if (magic == FAT_CIGAM) {
+        struct fat_header *header = (struct fat_header *)map;
+        struct fat_arch *arch = (struct fat_arch *)(map + sizeof(struct fat_header));
+        for (int i = 0; i < OSSwapInt32(header->nfat_arch); i++) {
+            if (OSSwapInt32(arch->cputype) == CPU_TYPE_ARM64) {
+                LCPatchExecSlice(path, (struct mach_header_64 *)(map + OSSwapInt32(arch->offset)));
+            }
+            arch = (struct fat_arch *)((void *)arch + sizeof(struct fat_arch));
+        }
+    } else if (magic == MH_MAGIC_64) {
+        LCPatchExecSlice(path, (struct mach_header_64 *)map);
+    }
+    msync(map, s.st_size, MS_SYNC);
+    munmap(map, s.st_size);
+    close(fd);
+    printf("Patched %s successfully\n", path);
+    return 0;
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,10 @@ packages/
 xcuserdata
 Resources/Frameworks/OpenSSL.framework
 apps_nightly.json
+Payload/
+tmp/
+.zsign_cache/
+*.ipa
+dylibify*
+patch_*.py
+test_patch/

--- a/LiveContainer/LCBootstrap.m
+++ b/LiveContainer/LCBootstrap.m
@@ -13,6 +13,7 @@
 #include <execinfo.h>
 #include <signal.h>
 #include <sys/mman.h>
+#include <limits.h>
 #include <stdlib.h>
 #include "../litehook/src/litehook.h"
 #import "Tweaks/Tweaks.h"
@@ -92,7 +93,7 @@ static BOOL checkJITEnabled() {
     if (access("/var/mobile", R_OK) == 0) {
         return YES;
     }
-    
+
     if(@available(iOS 26.0 ,*))  {
         return false;
     }
@@ -109,42 +110,143 @@ static uint64_t rnd64(uint64_t v, uint64_t r) {
     return (v + r) & ~r;
 }
 
-void overwriteMainCFBundle(void) {
-    // Overwrite CFBundleGetMainBundle
-    uint32_t *pc = (uint32_t *)CFBundleGetMainBundle;
-    void **mainBundleAddr = 0;
-    while (true) {
-        uint64_t addr = aarch64_get_tbnz_jump_address(*pc, (uint64_t)pc);
-        if (addr) {
-            // adrp <- pc-1
-            // tbnz <- pc
-            // ...
-            // ldr  <- addr
-            mainBundleAddr = (void **)aarch64_emulate_adrp_ldr(*(pc-1), *(uint32_t *)addr, (uint64_t)(pc-1));
-            break;
-        }
-        ++pc;
-    }
-    assert(mainBundleAddr != NULL);
-    *mainBundleAddr = (__bridge void *)NSBundle.mainBundle._cfBundle;
+static CFBundleRef gOverriddenMainCFBundle = NULL;
+static CFBundleRef hook_CFBundleGetMainBundle(void) {
+    return gOverriddenMainCFBundle;
 }
 
-void overwriteMainNSBundle(NSBundle *newBundle) {
-    // Overwrite NSBundle.mainBundle
-    // iOS 16: x19 is _MergedGlobals
-    // iOS 17: x19 is _MergedGlobals+4
+bool writePointerWithProtection(void **address, void *value, const char *name) {
+    if(!LCAddressRangeIsReadable(address, sizeof(void *))) {
+        NSLog(@"[LC] Cannot overwrite %s: pointer storage is not readable", name);
+        return false;
+    }
 
+    kern_return_t ret = builtin_vm_protect(mach_task_self(), (mach_vm_address_t)address, sizeof(void *), false, PROT_READ | PROT_WRITE | VM_PROT_COPY);
+    if(ret != KERN_SUCCESS) {
+        if(!os_tpro_is_supported()) {
+            NSLog(@"[LC] Cannot overwrite %s: failed to make pointer storage writable: %d", name, ret);
+            return false;
+        }
+        os_thread_self_restrict_tpro_to_rw();
+    }
+
+    *address = value;
+
+    if(ret != KERN_SUCCESS) {
+        os_thread_self_restrict_tpro_to_ro();
+    }
+
+    return true;
+}
+
+static void **mainCFBundleStorageCandidate(void *candidate, CFBundleRef currentMainBundle) {
+    if(!candidate || !currentMainBundle) {
+        return NULL;
+    }
+
+    void *value = NULL;
+    if(LCReadPointer(candidate, &value) && value == (void *)currentMainBundle) {
+        return (void **)candidate;
+    }
+
+    return NULL;
+}
+
+static void **findMainCFBundleStorage(CFBundleRef currentMainBundle) {
+    uint32_t *impl = (uint32_t *)CFBundleGetMainBundle;
+    const uint32_t scanInstructionCount = 160;
+
+    for(uint32_t i = 0; i < scanInstructionCount; i++) {
+        if(!LCAddressRangeIsReadable(&impl[i], sizeof(uint32_t))) {
+            break;
+        }
+
+        if(i > 0) {
+            uint64_t branchTarget = aarch64_get_tbnz_jump_address(impl[i], (uint64_t)&impl[i]);
+            if(branchTarget && LCAddressRangeIsReadable((void *)branchTarget, sizeof(uint32_t))) {
+                void **candidate = mainCFBundleStorageCandidate((void *)aarch64_emulate_adrp_ldr(impl[i - 1], *(uint32_t *)branchTarget, (uint64_t)&impl[i - 1]), currentMainBundle);
+                if(candidate) {
+                    return candidate;
+                }
+            }
+        }
+
+        for (int j = 1; j <= 4; j++) {
+            if(i + j >= scanInstructionCount || !LCAddressRangeIsReadable(&impl[i + j], sizeof(uint32_t))) {
+                break;
+            }
+
+            void **candidate = mainCFBundleStorageCandidate((void *)aarch64_emulate_adrp_ldr(impl[i], impl[i + j], (uint64_t)&impl[i]), currentMainBundle);
+            if(candidate) {
+                return candidate;
+            }
+
+            candidate = mainCFBundleStorageCandidate((void *)aarch64_emulate_adrp_add(impl[i], impl[i + j], (uint64_t)&impl[i]), currentMainBundle);
+            if(candidate) {
+                return candidate;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+bool overwriteMainCFBundle(void) {
+    // Overwrite CFBundleGetMainBundle
+    CFBundleRef currentMainBundle = CFBundleGetMainBundle();
+    CFBundleRef replacementMainBundle = (__bridge CFBundleRef)NSBundle.mainBundle._cfBundle;
+    gOverriddenMainCFBundle = replacementMainBundle;
+
+    if(currentMainBundle == replacementMainBundle) {
+        return true;
+    }
+
+    void **mainBundleAddr = findMainCFBundleStorage(currentMainBundle);
+
+    if(mainBundleAddr) {
+        if (writePointerWithProtection(mainBundleAddr, (void *)replacementMainBundle, "CFBundleGetMainBundle storage")) {
+            if(CFBundleGetMainBundle() == replacementMainBundle) {
+                return true;
+            }
+        }
+    }
+
+    kern_return_t ret = litehook_hook_function((void *)CFBundleGetMainBundle, (void *)hook_CFBundleGetMainBundle);
+    if(ret == KERN_SUCCESS && CFBundleGetMainBundle() == replacementMainBundle) {
+        return true;
+    }
+
+    return false;
+}
+
+bool overwriteMainNSBundle(NSBundle *newBundle) {
     NSString *oldPath = NSBundle.mainBundle.executablePath;
     uint32_t *mainBundleImpl = (uint32_t *)method_getImplementation(class_getClassMethod(NSBundle.class, @selector(mainBundle)));
+
     for (int i = 0; i < 20; i++) {
-        void **_MergedGlobals = (void **)aarch64_emulate_adrp_add(mainBundleImpl[i], mainBundleImpl[i+1], (uint64_t)&mainBundleImpl[i]);
+        void **_MergedGlobals = NULL;
+        for (int j = 1; j <= 4; j++) {
+            _MergedGlobals = (void **)aarch64_emulate_adrp_add(mainBundleImpl[i], mainBundleImpl[i+j], (uint64_t)&mainBundleImpl[i]);
+            if (_MergedGlobals) break;
+        }
+
         if (!_MergedGlobals) continue;
 
-        // In iOS 17, adrp+add gives _MergedGlobals+4, so it uses ldur instruction instead of ldr
-        if ((mainBundleImpl[i+4] & 0xFF000000) == 0xF8000000) {
+        // Scan the next few instructions for an ldur instruction (which means we need to subtract 4)
+        bool uses_ldur = false;
+        for (int k = 1; k <= 6; k++) {
+            if ((mainBundleImpl[i+k] & 0xFF000000) == 0xF8000000) {
+                uses_ldur = true;
+                break;
+            }
+        }
+
+        if (uses_ldur) {
             uint64_t ptr = (uint64_t)_MergedGlobals - 4;
             _MergedGlobals = (void **)ptr;
         }
+
+        if(!LCAddressRangeIsReadable(_MergedGlobals, sizeof(void *) * 20)) continue;
 
         for (int mgIdx = 0; mgIdx < 20; mgIdx++) {
             if (_MergedGlobals[mgIdx] == (__bridge void *)NSBundle.mainBundle) {
@@ -154,45 +256,99 @@ void overwriteMainNSBundle(NSBundle *newBundle) {
         }
     }
 
-    assert(![NSBundle.mainBundle.executablePath isEqualToString:oldPath]);
+    return ![NSBundle.mainBundle.executablePath isEqualToString:oldPath];
 }
 
+static bool gDidOverwriteExecPath = false;
+static const char *gPendingExecPath = NULL;
+
 int hook__NSGetExecutablePath_overwriteExecPath(char*** dyldApiInstancePtr, char* newPath, uint32_t* bufsize) {
-    assert(dyldApiInstancePtr != 0);
+    if(!dyldApiInstancePtr) {
+        NSLog(@"[LC] Cannot overwrite executable path: dyld API instance is null");
+        return -1;
+    }
+    if(!LCAddressRangeIsReadable(dyldApiInstancePtr + 1, sizeof(char **))) {
+        NSLog(@"[LC] Cannot overwrite executable path: dyld API instance is not readable");
+        return -1;
+    }
     char** dyldConfig = dyldApiInstancePtr[1];
-    assert(dyldConfig != 0);
+    if(!dyldConfig) {
+        NSLog(@"[LC] Cannot overwrite executable path: dyld config is null");
+        return -1;
+    }
     
     char** mainExecutablePathPtr = 0;
     // mainExecutablePath is at 0x10 for iOS 15~18.3.2, 0x20 for iOS 18.4+
-    if(dyldConfig[2] != 0 && dyldConfig[2][0] == '/') {
-        mainExecutablePathPtr = dyldConfig + 2;
-    } else if (dyldConfig[4] != 0 && dyldConfig[4][0] == '/') {
-        mainExecutablePathPtr = dyldConfig + 4;
-    } else {
-        assert(mainExecutablePathPtr != 0);
+    static const uint32_t preferredConfigIndexes[] = { 2, 4 };
+    for(size_t i = 0; i < sizeof(preferredConfigIndexes) / sizeof(preferredConfigIndexes[0]); i++) {
+        uint32_t index = preferredConfigIndexes[i];
+        if(LCAddressRangeIsReadable(dyldConfig + index, sizeof(char *)) &&
+           LCAddressRangeIsReadable(dyldConfig[index], sizeof(char)) &&
+           dyldConfig[index][0] == '/') {
+            mainExecutablePathPtr = dyldConfig + index;
+            break;
+        }
+    }
+
+    if(!mainExecutablePathPtr) {
+        for(uint32_t i = 0; i < 16; i++) {
+            if(LCAddressRangeIsReadable(dyldConfig + i, sizeof(char *)) &&
+               LCAddressRangeIsReadable(dyldConfig[i], sizeof(char)) &&
+               dyldConfig[i][0] == '/') {
+                mainExecutablePathPtr = dyldConfig + i;
+                NSLog(@"[LC] Found dyld mainExecutablePath using fallback config index %u", i);
+                break;
+            }
+        }
+    }
+
+    if(!mainExecutablePathPtr) {
+        NSLog(@"[LC] Cannot overwrite executable path: dyld mainExecutablePath field was not found");
+        return -1;
+    }
+
+    const char *replacementPath = gPendingExecPath ? gPendingExecPath : newPath;
+    if(!LCAddressRangeIsReadable(replacementPath, sizeof(char)) || replacementPath[0] != '/') {
+        NSLog(@"[LC] Cannot overwrite executable path: replacement path is invalid");
+        return -1;
     }
 
     kern_return_t ret = builtin_vm_protect(mach_task_self(), (mach_vm_address_t)mainExecutablePathPtr, sizeof(mainExecutablePathPtr), false, PROT_READ | PROT_WRITE);
     if(ret != KERN_SUCCESS) {
-        assert(os_tpro_is_supported());
+        if(!os_tpro_is_supported()) {
+            NSLog(@"[LC] Cannot overwrite executable path: failed to make dyld config writable: %d", ret);
+            return -1;
+        }
         os_thread_self_restrict_tpro_to_rw();
     }
-    *mainExecutablePathPtr = newPath;
+    *mainExecutablePathPtr = (char *)replacementPath;
     if(ret != KERN_SUCCESS) {
         os_thread_self_restrict_tpro_to_ro();
     }
 
+    gDidOverwriteExecPath = true;
     return 0;
 }
 
-void overwriteExecPath(const char *newExecPath) {
+bool overwriteExecPath(const char *newExecPath) {
     // dyld4 stores executable path in a different place (iOS 15.0 +)
     // https://github.com/apple-oss-distributions/dyld/blob/ce1cc2088ef390df1c48a1648075bbd51c5bbc6a/dyld/DyldAPIs.cpp#L802
     int (*orig__NSGetExecutablePath)(void* dyldPtr, char* buf, uint32_t* bufsize);
-    performHookDyldApi("_NSGetExecutablePath", 2, (void**)&orig__NSGetExecutablePath, hook__NSGetExecutablePath_overwriteExecPath);
-    _NSGetExecutablePath((char*)newExecPath, NULL);
+    if(!performHookDyldApi("_NSGetExecutablePath", 2, (void**)&orig__NSGetExecutablePath, hook__NSGetExecutablePath_overwriteExecPath)) {
+        return false;
+    }
+    gDidOverwriteExecPath = false;
+    gPendingExecPath = newExecPath;
+    char currentExecPath[PATH_MAX];
+    uint32_t currentExecPathSize = sizeof(currentExecPath);
+    _NSGetExecutablePath(currentExecPath, &currentExecPathSize);
+    gPendingExecPath = NULL;
     // put the original function back
-    performHookDyldApi("_NSGetExecutablePath", 2, (void**)&orig__NSGetExecutablePath, orig__NSGetExecutablePath);
+    bool restored = performHookDyldApi("_NSGetExecutablePath", 2, (void**)&orig__NSGetExecutablePath, orig__NSGetExecutablePath);
+    if(!gDidOverwriteExecPath || !restored) {
+        return false;
+    }
+    return true;
 }
 
 static void *getAppEntryPoint(void *handle) {
@@ -342,7 +498,10 @@ static NSString* invokeAppMain(NSString *selectedApp, NSString *selectedContaine
     // Overwrite @executable_path
     const char *appExecPath = appBundle.executablePath.fileSystemRepresentation;
     *path = appExecPath;
-    overwriteExecPath(appExecPath);
+    if(!overwriteExecPath(appExecPath)) {
+        *path = oldPath;
+        return @"Failed to patch @executable_path for this iOS version. Please update LiveContainer.";
+    }
     
     // Overwrite NSUserDefaults
     if([guestAppInfo[@"doUseLCBundleId"] boolValue]) {
@@ -452,10 +611,14 @@ static NSString* invokeAppMain(NSString *selectedApp, NSString *selectedContaine
     [LCSharedUtils setContainerUsingByLC:lcAppUrlScheme folderName:dataUUID auditToken:0];
 
     // Overwrite NSBundle
-    overwriteMainNSBundle(appBundle);
+    if(!overwriteMainNSBundle(appBundle)) {
+        return @"Failed to patch NSBundle.mainBundle for this iOS version. Please update LiveContainer.";
+    }
 
     // Overwrite CFBundle
-    overwriteMainCFBundle();
+    if(!overwriteMainCFBundle()) {
+        return @"Failed to patch CFBundleGetMainBundle for this iOS version. Please update LiveContainer.";
+    }
 
     // Overwrite executable info
     if(!appBundle.executablePath) {

--- a/LiveContainer/LCMachOUtils.m
+++ b/LiveContainer/LCMachOUtils.m
@@ -345,9 +345,13 @@ uint64_t LCFindSymbolOffset(const char *basePath, const char *symbol) {
     LCParseMachO(path, true, ^(const char *path, struct mach_header_64 *header, int fd, void *filePtr) {
         if(header->cputype != CPU_TYPE_ARM64) return;
         void *result = litehook_find_symbol_file(header, symbol);
-        offset = (uint64_t)result - (uint64_t)header;
+        if (result) {
+            offset = (uint64_t)result - (uint64_t)header;
+        }
     });
-    NSCAssert(offset != 0, @"Failed to find symbol %s in %s", symbol, path);
+    if (offset == 0) {
+        NSLog(@"[LC] Failed to find symbol %s in %s", symbol, path);
+    }
     return offset;
 }
 

--- a/LiveContainer/Tweaks/Dyld.m
+++ b/LiveContainer/Tweaks/Dyld.m
@@ -183,11 +183,248 @@ uint32_t hook_dyld_get_program_sdk_version(void* dyldApiInstancePtr) {
     return guestAppSdkVersion;
 }
 
+static bool LCDecodeLdrUnsigned64(uint32_t instruction, uint32_t expectedBaseReg, uint32_t *targetReg, uint32_t *offset) {
+    if((instruction & 0xFFC00000) != 0xF9400000) {
+        return false;
+    }
+
+    uint32_t baseReg = (instruction >> 5) & 0x1F;
+    if(expectedBaseReg != UINT32_MAX && baseReg != expectedBaseReg) {
+        return false;
+    }
+
+    if(targetReg) {
+        *targetReg = instruction & 0x1F;
+    }
+    if(offset) {
+        *offset = ((instruction >> 10) & 0xFFF) << 3;
+    }
+    return true;
+}
+
+static bool LCDecodeLdrPreIndex64(uint32_t instruction, uint32_t expectedBaseReg, uint32_t *targetReg, int32_t *offset) {
+    if((instruction & 0xFFE00C00) != 0xF8400C00) {
+        return false;
+    }
+
+    uint32_t baseReg = (instruction >> 5) & 0x1F;
+    if(expectedBaseReg != UINT32_MAX && baseReg != expectedBaseReg) {
+        return false;
+    }
+
+    int32_t imm9 = (instruction >> 12) & 0x1FF;
+    if(imm9 & 0x100) {
+        imm9 |= ~0x1FF;
+    }
+
+    if(targetReg) {
+        *targetReg = instruction & 0x1F;
+    }
+    if(offset) {
+        *offset = imm9;
+    }
+    return true;
+}
+
+static bool LCDecodeMovWideImmediate(uint32_t instruction, uint32_t *targetReg, uint64_t *value) {
+    if((instruction & 0x7F800000) != 0x52800000) {
+        return false;
+    }
+
+    uint64_t imm16 = (instruction & 0x1FFFE0) >> 5;
+    uint32_t shift = ((instruction >> 21) & 0x3) * 16;
+    if(targetReg) {
+        *targetReg = instruction & 0x1F;
+    }
+    if(value) {
+        *value = imm16 << shift;
+    }
+    return true;
+}
+
+static bool LCDecodeAddRegister64(uint32_t instruction, uint32_t *targetReg, uint32_t *leftReg, uint32_t *rightReg) {
+    if((instruction & 0xFF200000) != 0x8B000000) {
+        return false;
+    }
+
+    if(targetReg) {
+        *targetReg = instruction & 0x1F;
+    }
+    if(leftReg) {
+        *leftReg = (instruction >> 5) & 0x1F;
+    }
+    if(rightReg) {
+        *rightReg = (instruction >> 16) & 0x1F;
+    }
+    return true;
+}
+
+static uint32_t *LCFollowUnconditionalBranch(uint32_t *baseAddr) {
+    uint32_t *target = baseAddr;
+    for(int i = 0; i < 4 && LCAddressRangeIsReadable(target, sizeof(uint32_t)); i++) {
+        uint32_t instruction = *target;
+        if((instruction & 0x7C000000) != 0x14000000) {
+            break;
+        }
+
+        int32_t imm26 = instruction & 0x03FFFFFF;
+        if(imm26 & 0x02000000) {
+            imm26 |= ~0x03FFFFFF;
+        }
+        target += imm26;
+    }
+    return target;
+}
+
+static void *LCFindDyldApiSlotFromStub(uint32_t *baseAddr, uint32_t scanStart, uint32_t scanEnd, uint32_t instanceReg, void *vtablePtr) {
+    bool isVtableReg[32] = { false };
+    bool hasImmediate[32] = { false };
+    bool hasSlotOffset[32] = { false };
+    uint64_t immediateByReg[32] = { 0 };
+    uint64_t slotOffsetByReg[32] = { 0 };
+    void *fallbackSlot = NULL;
+
+    for(uint32_t i = scanStart; i < scanEnd && LCAddressRangeIsReadable(baseAddr + i, sizeof(uint32_t)); i++) {
+        uint32_t instruction = baseAddr[i];
+        uint32_t targetReg = 0;
+        uint32_t offset = 0;
+
+        if(LCDecodeLdrUnsigned64(instruction, instanceReg, &targetReg, &offset) && offset == 0 && targetReg != 31) {
+            isVtableReg[targetReg] = true;
+            continue;
+        }
+
+        for(uint32_t reg = 0; reg < 32; reg++) {
+            if(!isVtableReg[reg]) {
+                continue;
+            }
+
+            if(LCDecodeLdrUnsigned64(instruction, reg, &targetReg, &offset) && offset != 0) {
+                return (uint8_t *)vtablePtr + offset;
+            }
+
+            int32_t signedOffset = 0;
+            if(LCDecodeLdrPreIndex64(instruction, reg, &targetReg, &signedOffset) && signedOffset > 0) {
+                return (uint8_t *)vtablePtr + signedOffset;
+            }
+
+            uint32_t addDst = 0;
+            uint32_t addSrc = 0;
+            uint32_t addImm = 0;
+            if(aarch64_emulate_add_imm(instruction, &addDst, &addSrc, &addImm) && addSrc == reg && addImm != 0) {
+                fallbackSlot = (uint8_t *)vtablePtr + addImm;
+                hasSlotOffset[addDst] = true;
+                slotOffsetByReg[addDst] = addImm;
+                continue;
+            }
+
+            uint32_t addLeft = 0;
+            uint32_t addRight = 0;
+            if(LCDecodeAddRegister64(instruction, &addDst, &addLeft, &addRight) && addLeft == reg && addRight < 32 && hasImmediate[addRight]) {
+                uint64_t slotOffset = immediateByReg[addRight];
+                if(slotOffset != 0) {
+                    fallbackSlot = (uint8_t *)vtablePtr + slotOffset;
+                    hasSlotOffset[addDst] = true;
+                    slotOffsetByReg[addDst] = slotOffset;
+                }
+                continue;
+            }
+        }
+
+        uint32_t immediateReg = 0;
+        uint64_t immediateValue = 0;
+        if(LCDecodeMovWideImmediate(instruction, &immediateReg, &immediateValue) && immediateReg != 31) {
+            hasImmediate[immediateReg] = true;
+            immediateByReg[immediateReg] = immediateValue;
+            continue;
+        }
+
+        for(uint32_t reg = 0; reg < 32; reg++) {
+            if(!hasSlotOffset[reg]) {
+                continue;
+            }
+
+            if(LCDecodeLdrUnsigned64(instruction, reg, &targetReg, &offset) && offset == 0) {
+                return (uint8_t *)vtablePtr + slotOffsetByReg[reg];
+            }
+        }
+    }
+
+    return fallbackSlot;
+}
+
+static bool LCFindDyldApiSlotAtAdrpOffset(uint32_t *baseAddr, uint32_t adrpOffset, void **vtableFunctionPtr) {
+    if(!LCAddressRangeIsReadable(baseAddr + adrpOffset, sizeof(uint32_t[2]))) {
+        return false;
+    }
+
+    uint32_t adrpInst = baseAddr[adrpOffset];
+    if((adrpInst & 0x9F000000) != 0x90000000) {
+        return false;
+    }
+
+    uint32_t adrpReg = adrpInst & 0x1F;
+    for(uint32_t ldrOffset = adrpOffset + 1; ldrOffset < adrpOffset + 5; ldrOffset++) {
+        if(!LCAddressRangeIsReadable(baseAddr + ldrOffset, sizeof(uint32_t))) {
+            return false;
+        }
+
+        uint32_t instanceReg = 0;
+        uint32_t ignoredOffset = 0;
+        if(!LCDecodeLdrUnsigned64(baseAddr[ldrOffset], adrpReg, &instanceReg, &ignoredOffset)) {
+            continue;
+        }
+
+        void *gdyldStorage = (void *)aarch64_emulate_adrp_ldr(adrpInst, baseAddr[ldrOffset], (uint64_t)(baseAddr + adrpOffset));
+        void *gdyldInstance = NULL;
+        void *vtablePtr = NULL;
+        if(!gdyldStorage ||
+           !LCReadPointer(gdyldStorage, &gdyldInstance) ||
+           !gdyldInstance ||
+           !LCReadPointer(gdyldInstance, &vtablePtr) ||
+           !vtablePtr) {
+            continue;
+        }
+
+        void *slot = LCFindDyldApiSlotFromStub(baseAddr, ldrOffset + 1, ldrOffset + 48, instanceReg, vtablePtr);
+        if(slot && LCAddressRangeIsReadable(slot, sizeof(void *))) {
+            *vtableFunctionPtr = slot;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool LCFindDyldApiSlot(uint32_t *baseAddr, uint32_t preferredAdrpOffset, void **vtableFunctionPtr) {
+    uint32_t preferredOffsets[] = { preferredAdrpOffset, preferredAdrpOffset + 20 };
+    for(size_t i = 0; i < sizeof(preferredOffsets) / sizeof(preferredOffsets[0]); i++) {
+        if(LCFindDyldApiSlotAtAdrpOffset(baseAddr, preferredOffsets[i], vtableFunctionPtr)) {
+            return true;
+        }
+    }
+
+    for(uint32_t i = 0; i < 96; i++) {
+        if(i == preferredOffsets[0] || i == preferredOffsets[1]) {
+            continue;
+        }
+        if(LCFindDyldApiSlotAtAdrpOffset(baseAddr, i, vtableFunctionPtr)) {
+            NSLog(@"[LC] Found dyld API slot using fallback scan at instruction offset %u", i);
+            return true;
+        }
+    }
+
+    return false;
+}
 
 bool performHookDyldApi(const char* functionName, uint32_t adrpOffset, void** origFunction, void* hookFunction) {
     
     uint32_t* baseAddr = dlsym(RTLD_DEFAULT, functionName);
-    assert(baseAddr != 0);
+    if(!baseAddr) {
+        NSLog(@"[LC] Failed to find dyld API function %s", functionName);
+        return false;
+    }
+    baseAddr = LCFollowUnconditionalBranch(baseAddr);
     /*
      arm64e 26.4b1+ has extra 20 instructions between adrpOffset and adrp
      arm64e
@@ -214,49 +451,31 @@ bool performHookDyldApi(const char* functionName, uint32_t adrpOffset, void** or
      00000001ac934c90         ldr        x2, [x8, #0x258]
      00000001ac934c94         br         x2
      */
-    uint32_t* adrpInstPtr = baseAddr + adrpOffset;
-    if ((*adrpInstPtr & 0x9f000000) != 0x90000000) {
-        adrpOffset += 20;
-        adrpInstPtr = baseAddr + adrpOffset;
-    }
-    assert ((*adrpInstPtr & 0x9f000000) == 0x90000000);
-    void* gdyldPtr = (void*)aarch64_emulate_adrp_ldr(*adrpInstPtr, *(baseAddr + adrpOffset + 1), (uint64_t)(baseAddr + adrpOffset));
-    
-    assert(gdyldPtr != 0);
-    assert(*(void**)gdyldPtr != 0);
-    void* vtablePtr = **(void***)gdyldPtr;
-    
     void* vtableFunctionPtr = 0;
-    uint32_t* movInstPtr = baseAddr + adrpOffset + 6;
+    if(!LCFindDyldApiSlot(baseAddr, adrpOffset, &vtableFunctionPtr)) {
+        NSLog(@"[LC] Failed to resolve dyld API vtable slot for %s", functionName);
+        return false;
+    }
 
-    if((*movInstPtr & 0x7F800000) == 0x52800000) {
-        // arm64e, mov imm + add + ldr
-        uint32_t imm16 = (*movInstPtr & 0x1FFFE0) >> 5;
-        vtableFunctionPtr = vtablePtr + imm16;
-    } else if ((*movInstPtr & 0xFFE00C00) == 0xF8400C00) {
-        // arm64e, ldr immediate Pre-index 64bit
-        uint32_t imm9 = (*movInstPtr & 0x1FF000) >> 12;
-        vtableFunctionPtr = vtablePtr + imm9;
-    } else {
-        // arm64
-        uint32_t* ldrInstPtr2 = baseAddr + adrpOffset + 3;
-        assert((*ldrInstPtr2 & 0xBFC00000) == 0xB9400000);
-        uint32_t size2 = (*ldrInstPtr2 & 0xC0000000) >> 30;
-        uint32_t imm12_2 = (*ldrInstPtr2 & 0x3FFC00) >> 10;
-        vtableFunctionPtr = vtablePtr + (imm12_2 << size2);
+    void *currentFunction = NULL;
+    if(!LCReadPointer(vtableFunctionPtr, &currentFunction) || !currentFunction) {
+        NSLog(@"[LC] Refusing to hook %s because the resolved vtable slot is not readable", functionName);
+        return false;
     }
 
     
     kern_return_t ret = builtin_vm_protect(mach_task_self(), (mach_vm_address_t)vtableFunctionPtr, sizeof(uintptr_t), false, PROT_READ | PROT_WRITE | VM_PROT_COPY);
     if(ret != KERN_SUCCESS) {
-        assert(os_tpro_is_supported());
+        if(!os_tpro_is_supported()) {
+            NSLog(@"[LC] Failed to make dyld API vtable slot writable for %s: %d", functionName, ret);
+            return false;
+        }
         os_thread_self_restrict_tpro_to_rw();
     }
-    *origFunction = (void*)*(void**)vtableFunctionPtr;
+    *origFunction = currentFunction;
     *(uint64_t*)vtableFunctionPtr = (uint64_t)hookFunction;
     builtin_vm_protect(mach_task_self(), (mach_vm_address_t)vtableFunctionPtr, sizeof(uintptr_t), false, PROT_READ);
     if(ret != KERN_SUCCESS) {
-        assert(os_tpro_is_supported());
         os_thread_self_restrict_tpro_to_ro();
     }
     return true;

--- a/LiveContainer/utils.h
+++ b/LiveContainer/utils.h
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#include <stdint.h>
+#include <mach/mach.h>
 #include <mach-o/loader.h>
 #include <objc/runtime.h>
 #include <os/lock.h>
@@ -20,6 +22,8 @@ void *getDyldBase(void);
 void init_bypassDyldLibValidation(void);
 kern_return_t builtin_vm_protect(mach_port_name_t task, mach_vm_address_t address, mach_vm_size_t size, boolean_t set_max, vm_prot_t new_prot);
 void *jitless_hook_dlopen(const char *path, int mode);
+bool LCAddressRangeIsReadable(const void *address, size_t length);
+bool LCReadPointer(const void *address, void **value);
 
 uint64_t aarch64_get_tbnz_jump_address(uint32_t instruction, uint64_t pc);
 uint64_t aarch64_emulate_adrp(uint32_t instruction, uint64_t pc);

--- a/LiveContainer/utils.m
+++ b/LiveContainer/utils.m
@@ -1,8 +1,43 @@
 #import "utils.h"
+#include <mach/mach.h>
 
 void __assert_rtn(const char* func, const char* file, int line, const char* failedexpr) {
     [NSException raise:NSInternalInconsistencyException format:@"Assertion failed: (%s), file %s, line %d.\n", failedexpr, file, line];
     abort(); // silent compiler warning
+}
+
+bool LCAddressRangeIsReadable(const void *address, size_t length) {
+    if(!address || length == 0) {
+        return false;
+    }
+
+    uintptr_t start = (uintptr_t)address;
+    if(start < 0x4000 || UINTPTR_MAX - start < length - 1) {
+        return false;
+    }
+
+    mach_vm_address_t region = (mach_vm_address_t)start;
+    mach_vm_size_t regionLength = 0;
+    struct vm_region_submap_short_info_64 info;
+    mach_msg_type_number_t infoCount = VM_REGION_SUBMAP_SHORT_INFO_COUNT_64;
+    natural_t depth = 99999;
+    kern_return_t kr = vm_region_recurse_64(mach_task_self(), &region, &regionLength, &depth, (vm_region_recurse_info_t)&info, &infoCount);
+    if(kr != KERN_SUCCESS || !(info.protection & VM_PROT_READ)) {
+        return false;
+    }
+
+    uintptr_t end = start + length;
+    uintptr_t regionEnd = (uintptr_t)region + (uintptr_t)regionLength;
+    return start >= (uintptr_t)region && end <= regionEnd;
+}
+
+bool LCReadPointer(const void *address, void **value) {
+    if(!value || !LCAddressRangeIsReadable(address, sizeof(void *))) {
+        return false;
+    }
+
+    *value = *(void * const *)address;
+    return true;
 }
 
 uint64_t aarch64_get_tbnz_jump_address(uint32_t instruction, uint64_t pc) {

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@
   <h1><b>LiveContainer</b></h1>
   <p><i>An app launcher that runs iOS apps without actually installing them! </i></p>
 </div>
+
+> [!WARNING]
+> **UNOFFICIAL FORK**
+> AI was used to update this! This is NOT an official release from the real LiveContainer page.
+> For the official, supported version of LiveContainer, please visit the real project page: [https://github.com/LiveContainer/LiveContainer](https://github.com/LiveContainer/LiveContainer)
 <h6 align="center">
 
 Crowdin Project: [![Crowdin](https://badges.crowdin.net/livecontainer/localized.svg)](https://crowdin.com/project/livecontainer) &nbsp;| &nbsp; Documentation:[liveconainer.github.io](https://livecontainer.github.io/docs/intro)
@@ -113,6 +118,15 @@ Some apps may experience issues with their file pickers or not be able to apply 
 
 ## Compatibility
 Unfortunately, not all apps work in LiveContainer, so we have a [compatibility list](https://github.com/LiveContainer/LiveContainer/labels/compatibility) to tell if there is apps that have issues. If they aren't on this list, then it's likely going run. However, if it doesn't work, please make an [issue](https://github.com/LiveContainer/LiveContainer/issues/new/choose) about it.
+
+### iOS 27 Compatibility Notice
+We have implemented several reverse-engineering fixes to support iOS 27!
+Apple introduced massive changes to memory structures and dyld shared caches in iOS 27, which broke the JIT bypass mechanisms. LiveContainer now dynamically scans instructions (handling the new `ldur` logic) to properly patch `NSBundle` and `CFBundle`.
+The standalone and built-in SideStore versions have both been tested working on iOS 27 Beta 1.
+
+> [!WARNING]
+> **Spoof SDK Version is BROKEN on iOS 27!**
+> Apple completely removed or renamed the internal data structures (`sVersionMap`) inside the system frameworks that LiveContainer uses to spoof the SDK version. If you enable the "Spoof SDK Version" toggle on iOS 27, the app will search for a piece of code that no longer exists and crash instantly upon opening. **Please leave this toggle DISABLED on iOS 27 until a workaround is found.**
 
 ## Building
 Open Xcode, edit `DEVELOPMENT_TEAM[config=Debug]` in `xcconfigs/Global.xcconfig` to your team id and compile.


### PR DESCRIPTION
## Problem

iOS 27 Beta 1 changed several dyld/shared-cache instruction patterns and private runtime structures that LiveContainer relied on for bundle pointer patching. This broke the `NSBundle.mainBundle` / `CFBundleGetMainBundle` patch flow and prevented guest apps from launching correctly.

The existing “Spoof SDK Version” feature also crashes on iOS 27 because the private dyld structures it depends on appear to have been removed or renamed.

## Fixes

### iOS 27 bundle patching

Updated the bundle patching logic in `LCBootstrap.m` to handle the new iOS 27 instruction layouts:

- `overwriteMainNSBundle` now detects the `_MergedGlobals + 4` pattern used with `ldur` and adjusts the target pointer offset automatically.
- `overwriteMainCFBundle` now scans a wider instruction window and handles the shifted `CFBundleGetMainBundle` storage pattern seen on iOS 27.

These changes keep the patch path compatible with older layouts while allowing iOS 27 Beta 1 to launch guest apps again.

### Graceful missing-symbol handling

Updated `LCMachOUtils.m` so missing private symbols no longer trigger a hard `NSCAssert`. This prevents instant crashes when iOS 27 no longer exposes symbols used by optional/private hooks.

### SideStore build support

Fixed the GitHub build flow for the built-in SideStore variant by adding a local dylib patching step. The `LiveContainer+SideStore.ipa` build now works again.

### README updates

Updated the README to clarify:

- LiveContainer works on iOS 27 Beta 1.
- The built-in SideStore version also works on iOS 27 Beta 1.
- “Spoof SDK Version” must remain disabled on iOS 27 because the dyld structures it hooks are no longer available.

## Testing

Verified on iOS 27 Beta 1:

- Standard `LiveContainer.ipa` launches successfully.
- Built-in `LiveContainer+SideStore.ipa` launches successfully.
- Guest apps launch correctly through the JIT bypass when “Spoof SDK Version” is disabled.