### PR TITLE
Fix #1422: guard against nil _UISceneHostingEventDeferringExtension (multitask crash on iOS < 27)

### DIFF
--- a/MultitaskSupport/AppSceneViewController.m
+++ b/MultitaskSupport/AppSceneViewController.m
@@ -162,9 +162,16 @@
         config.sceneSpecification = specification;
         if (@available(iOS 27.0, *)) {} else {
             // on 27 manually adding this is not need, also setAdditionalExtensions: doesn't exist for some reason
-            config.additionalExtensions = [NSOrderedSet orderedSetWithArray:@[
-                PrivClass(_UISceneHostingEventDeferringExtension),
-            ]];
+            // Guard against a nil class: PrivClass()/NSClassFromString returns nil when the private
+            // class is unavailable or renamed on a given iOS version. Inserting nil into the array
+            // literal throws NSInvalidArgumentException, which crashed every multitask launch on
+            // iOS < 27 (#1422).
+            Class eventDeferringExtension = PrivClass(_UISceneHostingEventDeferringExtension);
+            if (eventDeferringExtension) {
+                config.additionalExtensions = [NSOrderedSet orderedSetWithObject:eventDeferringExtension];
+            } else {
+                NSLog(@"[LiveContainer] _UISceneHostingEventDeferringExtension unavailable on this iOS version; skipping additionalExtensions (was crashing #1422)");
+            }
         }
         self.hostingController = [[_UISceneHostingController alloc] initWithAdvancedConfiguration:config];
         FBScene *scene = [self.hostingController valueForKey:@"_fbScene"];


### PR DESCRIPTION
## Problem
`#1422` — Multitask is broken in the nightly on iOS 18 and below.

In `MultitaskSupport/AppSceneViewController.m`, the private class `_UISceneHostingEventDeferringExtension` is inserted directly into an `@[]` array literal via `PrivClass()` (= `NSClassFromString`):

```objc
config.additionalExtensions = [NSOrderedSet orderedSetWithArray:@[
    PrivClass(_UISceneHostingEventDeferringExtension),
]];
```

`@[x]` lowers to `+[NSArray arrayWithObjects:count:]`; when `NSClassFromString` returns **nil** (class unavailable/renamed on a given iOS version), inserting nil throws `NSInvalidArgumentException` at array-construction time and crashes the multitask launch. This `else` branch runs on everything below iOS 27, matching 'broken on iOS 18 and below, fine on newest'.

## Fix
Resolve the class into a local, nil-guard it, and only set `additionalExtensions` when it resolves (logging a one-line warning otherwise for field diagnosis):

```objc
Class eventDeferringExtension = PrivClass(_UISceneHostingEventDeferringExtension);
if (eventDeferringExtension) {
    config.additionalExtensions = [NSOrderedSet orderedSetWithObject:eventDeferringExtension];
} else {
    NSLog(@"[LiveContainer] _UISceneHostingEventDeferringExtension unavailable ...");
}
```

When the class resolves, behaviour is identical (1-element set). The only changed path is the former crash path.

## Testing
- Compiles cleanly (Xcode CI on my fork).
- Not yet device-tested on iOS 18; the added `NSLog` will confirm in the field whether the class is nil there. The change is correct hardening regardless.