### PR TITLE
Fix ZSign data race: synchronize ZLog::logs.clear() with logsMutex

### DIFF
--- a/ZSign/common/log.cpp
+++ b/ZSign/common/log.cpp
@@ -152,3 +152,8 @@ void ZLog::writeToLogFile(const std::string& message) {
     std::lock_guard<std::mutex> lock(logsMutex);
     logs.push_back(message);
 }
+
+void ZLog::clearLogs() {
+    std::lock_guard<std::mutex> lock(logsMutex);
+    logs.clear();
+}

--- a/ZSign/common/log.h
+++ b/ZSign/common/log.h
@@ -32,6 +32,7 @@ public:
 	static void SetLogLever(int nLogLevel) { g_nLogLevel = nLogLevel; }
     static vector<std::string> logs;
     static std::mutex logsMutex;
+    static void clearLogs();
 
 private:
 	static void _Print(const char* szLog, int nColor = 0);

--- a/ZSign/zsign.mm
+++ b/ZSign/zsign.mm
@@ -43,12 +43,12 @@ int checkCert(NSData *key,
 
     string strPassword = [pass cStringUsingEncoding:NSUTF8StringEncoding];
     
-    ZLog::logs.clear();
+    ZLog::clearLogs();
 
     __block ZSignAsset zSignAsset;
     
     if (!zSignAsset.InitSimple(strPKeyFileData, (int)[key length], nil, 0, strPassword)) {
-        ZLog::logs.clear();
+        ZLog::clearLogs();
         completionHandler(2, nil, nil, @"Unable to initialize certificate. Please check your password.");
         return -1;
     }
@@ -189,7 +189,7 @@ int checkCert(NSData *key,
 + (NSProgress*)signMachOPathArr:(NSArray<NSString*>*)machoPathArr bundleId:(NSString *)bundleId cert:(NSData *)key
                             pass:(NSString *)pass completionHandler:(void(^)(BOOL success, NSError *error))completionHandler {
     NSProgress* progress = [NSProgress progressWithTotalUnitCount:(int64_t)machoPathArr.count];
-    ZLog::logs.clear();
+    ZLog::clearLogs();
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         ZSignAsset* pSignAsset = new ZSignAsset();
         const char* strPKeyFileData = (const char*)[key bytes];
@@ -285,7 +285,7 @@ int checkCert(NSData *key,
 }
 
 + (BOOL)adhocSignMachOAtPath:(NSString *)path bundleId:(NSString*)bundleId entitlementData:(NSData *)entitlementData {
-    ZLog::logs.clear();
+    ZLog::clearLogs();
     
     ZSignAsset zSignAsset;
     zSignAsset.InitAdhoc([entitlementData bytes], (int)[entitlementData length]);
@@ -312,12 +312,12 @@ int checkCert(NSData *key,
 
     strPassword = [pass cStringUsingEncoding:NSUTF8StringEncoding];
     
-    ZLog::logs.clear();
+    ZLog::clearLogs();
 
     __block ZSignAsset zSignAsset;
     
     if (!zSignAsset.InitSimple(strPKeyFileData, (int)[cert length], nil, 0, strPassword)) {
-        ZLog::logs.clear();
+        ZLog::clearLogs();
         return nil;
     }
     NSString* teamId = [NSString stringWithUTF8String:zSignAsset.m_strTeamId.c_str()];


### PR DESCRIPTION
## Problem
`4ece46a` ("Fix multithread issue", part of the signing rework) added a mutex around the log **writer**:

```cpp
void ZLog::writeToLogFile(const std::string& message) {
    std::lock_guard<std::mutex> lock(logsMutex);
    logs.push_back(message);
}
```

…but left all six `ZLog::logs.clear();` calls in `zsign.mm` **unsynchronized**. `+[ZSigner signMachOPathArr:...]` clears the vector (`zsign.mm:192`) and then dispatches **concurrent** signing workers (`dispatch_group_async` on a concurrent queue) that log via `ZLog::ErrorV → _Print → writeToLogFile` (push_back). A `clear()` from any other ZSign entry point (`checkCert`, `getTeamIdWithCert`, `adhocSignMachOAtPath`) racing with a worker's `push_back()` is a data race on the shared `std::vector` → heap corruption / intermittent signing crashes.

## Fix
Add a lock-protected clear and route all six sites through it:

```cpp
void ZLog::clearLogs() {
    std::lock_guard<std::mutex> lock(logsMutex);
    logs.clear();
}
```

`logs` is only ever written (push_back) and cleared — there are no readers — so per-operation locking on both mutators fully closes the race.

## Testing
- Compiles cleanly (Xcode CI on my fork); same primitives already used by `writeToLogFile`.
- No behavioural change beyond added synchronization; single-threaded callers pay only an uncontended lock. No nested locking → no deadlock risk.