### PR TITLE
Remove ⁠UIInterfaceOrientationUpsideDown⁠ from Info.plist to fix layout bugs on iPad

### DIFF
--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -220,7 +220,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             .navigationTitle("lc.appList.myApps".loc)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    if sharedModel.multiLCStatus != 2 {
+                    //if sharedModel.multiLCStatus != 2 {
                         if !installprogressVisible {
                             Menu {
                                 
@@ -237,7 +237,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                         } else {
                             ProgressView().progressViewStyle(.circular).padding(.horizontal, 8)
                         }
-                    }
+                    //}
                 }
                 ToolbarItem(placement: .topBarLeading) {
                     if(UserDefaults.sideStoreExist()) {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -220,7 +220,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             .navigationTitle("lc.appList.myApps".loc)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    //if sharedModel.multiLCStatus != 2 {
+                    if sharedModel.multiLCStatus != 2 {
                         if !installprogressVisible {
                             Menu {
                                 
@@ -237,7 +237,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
                         } else {
                             ProgressView().progressViewStyle(.circular).padding(.horizontal, 8)
                         }
-                    //}
+                    }
                 }
                 ToolbarItem(placement: .topBarLeading) {
                     if(UserDefaults.sideStoreExist()) {

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -305,14 +305,13 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
+		
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
+		
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportsDocumentBrowser</key>


### PR DESCRIPTION
Hi LiveContainer Team,
When testing Guest Apps locked to a single orientation (Portrait-only or Landscape-only), iPadOS still forces the UI to rotate or glitch inside LiveContainer.

The Cause
This is NOT related to iPad multitasking. It happens because LiveContainer's ⁠Info.plist⁠ includes ⁠UIInterfaceOrientationUpsideDown⁠. This forces the system to recalculate layout boundaries for the Guest App, breaking fixed-orientation UIs.

Solution
In LiveContainer’s ⁠Info.plist⁠ (for iPad), please keep only ⁠Portrait⁠ and ⁠LandscapeRight⁠, and remove ⁠UpsideDown⁠.

Why it works
By removing ⁠UpsideDown⁠, the host container perfectly matches native device behavior. iPadOS will completely stop unexpected orientation recalculations, keeping fixed-orientation Guest Apps 100% locked and stable.

Thanks for your hard work!