### PR TITLE
Internet fix

### DIFF
--- a/LiveContainer/LCSharedUtils.m
+++ b/LiveContainer/LCSharedUtils.m
@@ -121,6 +121,14 @@ extern NSBundle *lcMainBundle;
 }
 
 + (BOOL)launchToGuestApp {
+    if(![NSThread isMainThread]) {
+        __block BOOL didLaunch = NO;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            didLaunch = [self launchToGuestApp];
+        });
+        return didLaunch;
+    }
+
     NSString *urlScheme = nil;
     NSString *tsPath = [NSString stringWithFormat:@"%@/../_TrollStore", NSBundle.mainBundle.bundlePath];
     UIApplication *application = [NSClassFromString(@"UIApplication") sharedApplication];

--- a/LiveContainerSwiftUI/Models/LCAppInfo.m
+++ b/LiveContainerSwiftUI/Models/LCAppInfo.m
@@ -9,6 +9,30 @@
 
 uint32_t dyld_get_sdk_version(const struct mach_header* mh);
 
+static BOOL LCAppContainsEmbeddedTweakRuntime(NSString *bundlePath) {
+    if (bundlePath.length == 0) {
+        return NO;
+    }
+
+    static NSArray<NSString *> *runtimePaths;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        runtimePaths = @[
+            @"Frameworks/CydiaSubstrate.framework/CydiaSubstrate",
+            @"Frameworks/ElleKit.framework/ElleKit",
+            @"Frameworks/libsubstrate.dylib"
+        ];
+    });
+
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    for (NSString *runtimePath in runtimePaths) {
+        if ([fileManager fileExistsAtPath:[bundlePath stringByAppendingPathComponent:runtimePath]]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 @implementation LCAppInfo
 
 - (instancetype)initWithBundlePath:(NSString*)bundlePath {
@@ -67,6 +91,21 @@ uint32_t dyld_get_sdk_version(const struct mach_header* mh);
         }
 
         _autoSaveDisabled = false;
+
+        // Pre-injected apps already initialize their own hook runtime and tweaks while
+        // the guest executable is being loaded. Injecting TweakLoader as another direct
+        // dependency changes that initializer order and can make the two hook stacks
+        // interfere with each other. Load TweakLoader after the guest initializers
+        // instead, while keeping LiveContainer's UIKit compatibility hooks available.
+        if (_info[@"dontInjectTweakLoader"] == nil && LCAppContainsEmbeddedTweakRuntime(bundlePath)) {
+            _info[@"dontInjectTweakLoader"] = @YES;
+            if (_info[@"dontLoadTweakLoader"] == nil) {
+                _info[@"dontLoadTweakLoader"] = @NO;
+            }
+            _info[@"LCPatchRevision"] = @(-1);
+            NSLog(@"[LCAppInfo] Embedded tweak runtime detected in %@; TweakLoader will be loaded after guest initializers.", bundlePath.lastPathComponent);
+            [self save];
+        }
     }
     return self;
 }

--- a/MultitaskSupport/PiPManager.m
+++ b/MultitaskSupport/PiPManager.m
@@ -16,6 +16,7 @@ API_AVAILABLE(ios(16.0))
 @property(nonatomic, strong) AVPictureInPictureController *pipController;
 @property(nonatomic) AppSceneViewController* displayingVC;
 @property(nonatomic) BOOL ownsAudioSession;
+@property(nonatomic) NSUInteger pipStartGeneration;
 @end
 
 
@@ -88,7 +89,35 @@ static PiPManager* sharedInstance = nil;
     self.ownsAudioSession = NO;
 }
 
+- (void)startPictureInPictureWhenPossibleWithAttempt:(NSUInteger)attempt generation:(NSUInteger)generation {
+    AVPictureInPictureController *controller = self.pipController;
+    if (!controller || generation != self.pipStartGeneration) {
+        return;
+    }
+
+    if (controller.isPictureInPictureActive) {
+        return;
+    }
+
+    if (controller.isPictureInPicturePossible) {
+        NSLog(@"[PiPManager] Starting LiveContainer PiP.");
+        [controller startPictureInPicture];
+        return;
+    }
+
+    if (attempt >= 10) {
+        NSLog(@"[PiPManager] LiveContainer PiP is not possible after waiting; giving up.");
+        [self deactivateAudioSessionForLiveContainerPiP];
+        return;
+    }
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self startPictureInPictureWhenPossibleWithAttempt:attempt + 1 generation:generation];
+    });
+}
+
 - (void)startPiPWithVC:(AppSceneViewController*)vc {
+    self.pipStartGeneration++;
     [self.pipController stopPictureInPicture];
     if(self.displayingVC) {
         [self.displayingDecoratedVC unminimizeWindowPiP];
@@ -113,14 +142,13 @@ static PiPManager* sharedInstance = nil;
         self.pipController.canStartPictureInPictureAutomaticallyFromInline = YES;
         self.pipController.delegate = self;
         [self.pipController setValue:@1 forKey:@"controlsStyle"];
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            [self.pipController startPictureInPicture];
-        });
+        [self startPictureInPictureWhenPossibleWithAttempt:0 generation:self.pipStartGeneration];
     });
 
 }
 
 - (void)stopPiP {
+    self.pipStartGeneration++;
     [self.pipController stopPictureInPicture];
     if (!self.pipController.isPictureInPictureActive) {
         [self deactivateAudioSessionForLiveContainerPiP];

--- a/MultitaskSupport/PiPManager.m
+++ b/MultitaskSupport/PiPManager.m
@@ -15,6 +15,7 @@ API_AVAILABLE(ios(16.0))
 @property(nonatomic, strong) AVPictureInPictureVideoCallViewController *pipVideoCallViewController;
 @property(nonatomic, strong) AVPictureInPictureController *pipController;
 @property(nonatomic) AppSceneViewController* displayingVC;
+@property(nonatomic) BOOL ownsAudioSession;
 @end
 
 
@@ -45,10 +46,46 @@ static PiPManager* sharedInstance = nil;
 }
 
 - (instancetype)init {
-    NSError* error = nil;
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
-    [[AVAudioSession sharedInstance] setActive:YES withOptions:1 error:&error];
+    self = [super init];
     return self;
+}
+
+- (void)activateAudioSessionForLiveContainerPiP {
+    // AVAudioSession is process-global. Configuring it when the singleton is merely
+    // accessed can interrupt media owned by a guest process (for example YouPiP or
+    // background playback). Only take an audio session while LC's own window PiP is
+    // actually running, and mix with the guest's audio instead of replacing it.
+    AVAudioSession *audioSession = AVAudioSession.sharedInstance;
+    NSError *error = nil;
+    BOOL categoryConfigured = [audioSession setCategory:AVAudioSessionCategoryPlayback
+                                                    mode:AVAudioSessionModeMoviePlayback
+                                                 options:AVAudioSessionCategoryOptionMixWithOthers
+                                                   error:&error];
+    if (!categoryConfigured) {
+        NSLog(@"[PiPManager] Unable to configure the LiveContainer PiP audio session: %@", error);
+        return;
+    }
+
+    error = nil;
+    self.ownsAudioSession = [audioSession setActive:YES error:&error];
+    if (!self.ownsAudioSession) {
+        NSLog(@"[PiPManager] Unable to activate the LiveContainer PiP audio session: %@", error);
+    }
+}
+
+- (void)deactivateAudioSessionForLiveContainerPiP {
+    if (!self.ownsAudioSession) {
+        return;
+    }
+
+    NSError *error = nil;
+    [AVAudioSession.sharedInstance setActive:NO
+                                 withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                       error:&error];
+    if (error) {
+        NSLog(@"[PiPManager] Unable to deactivate the LiveContainer PiP audio session: %@", error);
+    }
+    self.ownsAudioSession = NO;
 }
 
 - (void)startPiPWithVC:(AppSceneViewController*)vc {
@@ -58,6 +95,7 @@ static PiPManager* sharedInstance = nil;
         [self pictureInPictureControllerDidStopPictureInPicture:self.pipController];
     }
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)([self.pipController isPictureInPictureActive] * 0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self activateAudioSessionForLiveContainerPiP];
         self.displayingVC = vc;
         self.pipVideoCallViewController = [AVPictureInPictureVideoCallViewController new];
         self.pipVideoCallViewController.preferredContentSize = vc.view.bounds.size;
@@ -84,6 +122,9 @@ static PiPManager* sharedInstance = nil;
 
 - (void)stopPiP {
     [self.pipController stopPictureInPicture];
+    if (!self.pipController.isPictureInPictureActive) {
+        [self deactivateAudioSessionForLiveContainerPiP];
+    }
 }
 
 // PIP delegate
@@ -128,11 +169,13 @@ static PiPManager* sharedInstance = nil;
         self.pipController = nil;
         self.pipVideoCallViewController = nil;
     }
+    [self deactivateAudioSessionForLiveContainerPiP];
     // FIXME: HostingController path causes a tiny flicker during transition to and from PiP.
 }
 
 - (void)pictureInPictureController:(AVPictureInPictureController *)pictureInPictureController failedToStartPictureInPictureWithError:(NSError *)error {
     NSLog(@"%@", error.description);
+    [self deactivateAudioSessionForLiveContainerPiP];
 }
 
 - (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(NSObject*)object change:(NSDictionary<NSString *,id> *) change context:(void *) context {


### PR DESCRIPTION
## Issue

Fix apps with embedded tweak runtimes failing to use networking in LiveContainer.

Some guest apps already ship with a tweak runtime such as CydiaSubstrate, ElleKit, or libsubstrate. Injecting LiveContainer's TweakLoader as an early dependency changes initializer order and can make the guest app's own hook runtime interfere with LiveContainer's hooks.

---

## fixed

This change detects embedded tweak runtimes and defers TweakLoader loading until after guest initializers, while still keeping LiveContainer's UIKit compatibility hooks available.

---

##### Cowork with Codex. :)