### PR TITLE
Launch mode switching

### DIFF
--- a/LiveContainerSwiftUI/App/AppDelegate.swift
+++ b/LiveContainerSwiftUI/App/AppDelegate.swift
@@ -1,6 +1,88 @@
 import UIKit
 import SwiftUI
 import Intents
+import AppIntents
+import CoreFoundation
+
+private let lcActionButtonSwitchNotification = "com.kdt.livecontainer.actionButtonSwitch" as CFString
+
+@available(iOS 16.0, *)
+struct LCActionButtonSwitchIntent: AppIntent {
+    static var title: LocalizedStringResource = "lc.launchMode.switchToLiveProcess"
+    static var description = IntentDescription("Ask the active LiveContainer guest app to switch to LiveProcess. Run this shortcut three times to show the confirmation menu.")
+    static var openAppWhenRun = false
+
+    func perform() async throws -> some IntentResult {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(lcActionButtonSwitchNotification),
+            nil,
+            nil,
+            true
+        )
+        return .result()
+    }
+}
+
+@available(iOS 16.0, *)
+struct LCAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: LCActionButtonSwitchIntent(),
+            phrases: ["Switch \(.applicationName) to LiveProcess"],
+            shortTitle: "lc.launchMode.switchToLiveProcess",
+            systemImageName: "arrow.left.arrow.right"
+        )
+    }
+
+    static var shortcutTileColor: ShortcutTileColor = .blue
+}
+
+enum LCLaunchModeSwitchDefaults {
+    static let pendingBundleID = "LCPendingLiveProcessBundleID"
+    static let pendingDataUUID = "LCPendingLiveProcessDataUUID"
+}
+
+@MainActor
+enum LCLaunchModeSwitchManager {
+    private static var isLaunching = false
+
+    static func launchPendingLiveProcessAppIfNeeded() {
+        guard !isLaunching else { return }
+
+        let defaults = UserDefaults.standard
+        guard let bundleID = defaults.string(forKey: LCLaunchModeSwitchDefaults.pendingBundleID),
+              let dataUUID = defaults.string(forKey: LCLaunchModeSwitchDefaults.pendingDataUUID)
+        else {
+            return
+        }
+
+        let model = DataManager.shared.model
+        guard let app = (model.apps + model.hiddenApps).first(where: {
+            $0.appInfo.relativeBundlePath == bundleID
+        }) else {
+            defaults.removeObject(forKey: LCLaunchModeSwitchDefaults.pendingBundleID)
+            defaults.removeObject(forKey: LCLaunchModeSwitchDefaults.pendingDataUUID)
+            defaults.set("Unable to find the app requested for LiveProcess: \(bundleID)", forKey: "error")
+            return
+        }
+
+        isLaunching = true
+        defaults.removeObject(forKey: LCLaunchModeSwitchDefaults.pendingBundleID)
+        defaults.removeObject(forKey: LCLaunchModeSwitchDefaults.pendingDataUUID)
+        NSLog("[LC][LaunchModeSwitch] relaunching \(bundleID) with container \(dataUUID) in LiveProcess")
+
+        Task {
+            defer { isLaunching = false }
+            do {
+                try await app.runApp(multitask: true, containerFolderName: dataUUID)
+            } catch {
+                NSLog("[LC][LaunchModeSwitch] LiveProcess relaunch failed: \(error.localizedDescription)")
+                defaults.set(error.localizedDescription, forKey: "error")
+            }
+        }
+    }
+}
 
 @objc class AppDelegate: UIResponder, UIApplicationDelegate {
         

--- a/LiveContainerSwiftUI/Models/LCAppModel.swift
+++ b/LiveContainerSwiftUI/Models/LCAppModel.swift
@@ -230,6 +230,8 @@ class LCAppModel: ObservableObject, Hashable {
             }
             
         }
+
+        try validateJITLessCertificateForLaunchIfNeeded(bundleIdOverride: bundleIdOverride)
         
         // this is rerouted to bringing app to front, so not needed here?
 //        if(MultitaskManager.isUsing(container: uiSelectedContainer!.folderName)) {
@@ -375,6 +377,27 @@ class LCAppModel: ObservableObject, Hashable {
         await MainActor.run {
             isAppRunning = false
         }
+    }
+
+    private func validateJITLessCertificateForLaunchIfNeeded(bundleIdOverride: String?) throws {
+        #if targetEnvironment(simulator)
+        return
+        #else
+        if #available(iOS 26.0, *) {
+            // Built-in SideStore is handled specially by LCBootstrap and does not require LiveContainer's
+            // imported signing certificate before launch.
+            if bundleIdOverride == "builtinSideStore" {
+                return
+            }
+
+            guard LCSharedUtils.certificatePassword() != nil else {
+                throw [
+                    "lc.signer.noCertificateFoundErr".loc,
+                    "lc.appList.jitlessCertificateRequiredIOS26".loc
+                ].joined(separator: "\n\n")
+            }
+        }
+        #endif
     }
     
     func forceResign() async throws {

--- a/LiveContainerSwiftUI/Views/AppList/LCAppBanner.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppBanner.swift
@@ -265,13 +265,23 @@ struct LCAppBanner : View {
 
         // Multitask Toggle
         if #available(iOS 16.0, *) {
-            let runTitle = model.shouldLaunchInMultitaskMode ? "lc.appBanner.run".loc : "lc.appBanner.multitask".loc
-            let runImage = model.shouldLaunchInMultitaskMode ? "play.fill" : "macwindow.badge.plus"
-            
-            let multitaskAction = UIAction(title: runTitle, image: UIImage(systemName: runImage)) { _ in
-                Task { await runApp(multitask: !model.shouldLaunchInMultitaskMode) }
+            let liveContainerAction = UIAction(
+                title: "lc.launchMode.runInLiveContainer".loc,
+                image: UIImage(systemName: "app.fill")
+            ) { _ in
+                Task { await runApp(multitask: false) }
             }
-            sectionChildren.append(multitaskAction)
+            let liveProcessAction = UIAction(
+                title: "lc.launchMode.runInLiveProcess".loc,
+                image: UIImage(systemName: "macwindow.badge.plus")
+            ) { _ in
+                Task { await runApp(multitask: true) }
+            }
+            sectionChildren.append(UIMenu(
+                title: "lc.launchMode.runMode".loc,
+                image: UIImage(systemName: "arrow.left.arrow.right"),
+                children: [liveContainerAction, liveProcessAction]
+            ))
         }
 
         // Submenu: Add to Home Screen

--- a/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/LCAppListView.swift
@@ -491,6 +491,7 @@ struct LCAppListView : View, LCAppBannerDelegate, LCAppModelDelegate {
             app.delegate = self
         }
         didAppear = true
+        LCLaunchModeSwitchManager.launchPendingLiveProcessAppIfNeeded()
     }
     
     

--- a/MultitaskSupport/AppSceneViewController.h
+++ b/MultitaskSupport/AppSceneViewController.h
@@ -39,8 +39,8 @@ API_AVAILABLE(ios(16.0))
 - (void)updateSettingsWithBlock:(void(^)(UIMutableApplicationSceneSettings *settings))block;
 - (void)appTerminationCleanUp;
 - (void)terminate;
+- (void)switchToLiveContainer;
 - (void)openURLScheme:(NSString *)urlString;
 - (void)handleStatusBarTapAction:(UIAction *)action;
 - (BOOL)usesHostingControllerAPI;
 @end
-

--- a/MultitaskSupport/AppSceneViewController.m
+++ b/MultitaskSupport/AppSceneViewController.m
@@ -27,6 +27,7 @@
 @property(nonatomic) NSString *sceneID;
 @property(nonatomic) NSExtension* extension;
 @property(nonatomic) bool isAppTerminationCleanUpCalled;
+@property(nonatomic) bool isSwitchToLiveContainerRequested;
 @end
 
 @implementation AppSceneViewController
@@ -240,6 +241,20 @@
     }
 }
 
+- (void)switchToLiveContainer {
+    if(self.isSwitchToLiveContainerRequested) {
+        return;
+    }
+
+    self.isSwitchToLiveContainerRequested = true;
+    NSLog(@"[LC][LaunchModeSwitch] stopping LiveProcess guest %@ to relaunch container %@ in LiveContainer", self.bundleId, self.dataUUID);
+    if(self.isAppRunning) {
+        [self terminate];
+    } else {
+        [self appTerminationCleanUp];
+    }
+}
+
 - (void)_performActionsForUIScene:(UIScene *)scene withUpdatedFBSScene:(id)fbsScene settingsDiff:(FBSSceneSettingsDiff *)diff fromSettings:(UIApplicationSceneSettings *)settings transitionContext:(id)context lifecycleActionType:(uint32_t)actionType {
     if(!self.isAppRunning) {
         [self appTerminationCleanUp];
@@ -352,8 +367,19 @@
         }
         self.presenter = nil;
         
-        [self.delegate appSceneVCAppDidExit:self];
         [MultitaskManager unregisterMultitaskContainerWithContainer:self.dataUUID];
+        [self.delegate appSceneVCAppDidExit:self];
+
+        if(self.isSwitchToLiveContainerRequested) {
+            NSUserDefaults *defaults = NSUserDefaults.lcUserDefaults;
+            [defaults setObject:self.bundleId forKey:@"selected"];
+            [defaults setObject:self.dataUUID forKey:@"selectedContainer"];
+            [defaults synchronize];
+            NSLog(@"[LC][LaunchModeSwitch] relaunching %@ with container %@ in LiveContainer", self.bundleId, self.dataUUID);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [LCSharedUtils launchToGuestApp];
+            });
+        }
     });
 }
 

--- a/MultitaskSupport/DecoratedAppSceneViewController.m
+++ b/MultitaskSupport/DecoratedAppSceneViewController.m
@@ -44,6 +44,10 @@
                 [PiPManager.shared startPiPWithVC:self.appSceneVC];
             }
         }],
+        [UIAction actionWithTitle:@"lc.launchMode.switchToLiveContainer".loc image:[UIImage systemImageNamed:@"arrow.left.arrow.right"] identifier:nil handler:^(UIAction * _Nonnull action) {
+            self.isAppTerminationRequested = true;
+            [self.appSceneVC switchToLiveContainer];
+        }],
         [UICustomViewMenuElement elementWithViewProvider:^UIView *(UICustomViewMenuElement *element) {
             return [self scaleSliderViewWithTitle:@"lc.multitask.scale".loc min:0.5 max:2.0 value:self.scaleRatio stepInterval:0.01];
         }]

--- a/MultitaskSupport/MultitaskAppWindow.swift
+++ b/MultitaskSupport/MultitaskAppWindow.swift
@@ -45,6 +45,7 @@ struct MultitaskAppInfo {
 @available(iOS 16.1, *)
 struct AppSceneViewSwiftUI: UIViewControllerRepresentable {
     @Binding var show: Bool
+    @Binding var switchToLiveContainerRequested: Bool
     let bundleId: String
     let dataUUID: String
     let initSize: CGSize
@@ -111,7 +112,9 @@ struct AppSceneViewSwiftUI: UIViewControllerRepresentable {
     
     func updateUIViewController(_ vc: UIViewController, context _: Context) {
         if let vc = vc as? AppSceneViewController {
-            if !show {
+            if switchToLiveContainerRequested {
+                vc.switchToLiveContainer()
+            } else if !show {
                 vc.terminate()
             }
         }
@@ -126,6 +129,7 @@ struct MultitaskAppWindow: View {
     @State var errorMessage: String? = nil
     @State private var hasScheduledAutoClose = false
     @State private var didRequestManualClose = false
+    @State private var switchToLiveContainerRequested = false
     @EnvironmentObject var sceneDelegate: SceneDelegate
     @Environment(\.openWindow) var openWindow
     @AppStorage("LCMultitaskMode", store: LCUtils.appGroupUserDefault) var multitaskMode: MultitaskMode = .virtualWindow
@@ -142,7 +146,8 @@ struct MultitaskAppWindow: View {
         let isVirtualWindowMode = multitaskMode == .virtualWindow
         if show, let appInfo {
             GeometryReader { geometry in
-                AppSceneViewSwiftUI(show: $show, bundleId: appInfo.bundleId, dataUUID: appInfo.dataUUID, initSize: geometry.size,
+                AppSceneViewSwiftUI(show: $show, switchToLiveContainerRequested: $switchToLiveContainerRequested,
+                                    bundleId: appInfo.bundleId, dataUUID: appInfo.dataUUID, initSize: geometry.size,
                                     onAppInitialize: { pid, error in
                     DispatchQueue.main.async {
                         if error == nil {
@@ -159,6 +164,14 @@ struct MultitaskAppWindow: View {
             }
             .ignoresSafeArea(.all, edges: .all)
             .navigationTitle(Text("\(appInfo.displayName) - \(String(pid))"))
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("lc.launchMode.switchToLiveContainer".loc, systemImage: "arrow.left.arrow.right") {
+                        didRequestManualClose = true
+                        switchToLiveContainerRequested = true
+                    }
+                }
+            }
             .onReceive(pub) { out in
                 if let scene1 = sceneDelegate.window?.windowScene, let scene2 = out.object as? UIWindowScene, scene1 == scene2 {
                     show = false

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -18305,6 +18305,612 @@
         }
       }
     },
+    "lc.launchMode.runInLiveContainer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تشغيل في LiveContainer"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In LiveContainer ausführen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run in LiveContainer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejecutar en LiveContainer"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter dans LiveContainer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esegui in LiveContainer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveContainerで実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveContainer에서 실행"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uruchom w LiveContainer"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Executar no LiveContainer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запустить в LiveContainer"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kör i LiveContainer"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveContainer'da çalıştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chạy trong LiveContainer"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 LiveContainer 中运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 LiveContainer 中執行"
+          }
+        }
+      }
+    },
+    "lc.launchMode.runInLiveProcess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تشغيل في LiveProcess"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In LiveProcess ausführen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run in LiveProcess"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejecutar en LiveProcess"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter dans LiveProcess"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esegui in LiveProcess"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveProcessで実行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveProcess에서 실행"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uruchom w LiveProcess"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Executar no LiveProcess"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запустить в LiveProcess"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kör i LiveProcess"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveProcess'te çalıştır"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chạy trong LiveProcess"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 LiveProcess 中运行"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 LiveProcess 中執行"
+          }
+        }
+      }
+    },
+    "lc.launchMode.runMode" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "وضع التشغيل"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausführungsmodus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de ejecución"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode d'exécution"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità di esecuzione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行モード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실행 모드"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb uruchamiania"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de execução"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим запуска"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Körläge"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çalıştırma modu"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chế độ chạy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行模式"
+          }
+        }
+      }
+    },
+    "lc.launchMode.switchToLiveContainer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التبديل إلى LiveContainer"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zu LiveContainer wechseln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch to LiveContainer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar a LiveContainer"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basculer vers LiveContainer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passa a LiveContainer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveContainerに切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveContainer로 전환"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przełącz na LiveContainer"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar para LiveContainer"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переключиться на LiveContainer"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Byt till LiveContainer"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveContainer'a geç"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chuyển sang LiveContainer"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换到 LiveContainer"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換到 LiveContainer"
+          }
+        }
+      }
+    },
+    "lc.launchMode.switchToLiveProcess" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "التبديل إلى LiveProcess"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zu LiveProcess wechseln"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch to LiveProcess"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar a LiveProcess"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basculer vers LiveProcess"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passa a LiveProcess"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveProcessに切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveProcess로 전환"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przełącz na LiveProcess"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alternar para LiveProcess"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переключиться на LiveProcess"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Byt till LiveProcess"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LiveProcess'e geç"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chuyển sang LiveProcess"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换到 LiveProcess"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切換到 LiveProcess"
+          }
+        }
+      }
+    },
+    "lc.launchMode.switchToLiveProcessMessage" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سيتم إغلاق التطبيق الحالي وإعادة تشغيله في LiveProcess. لن يتم الاحتفاظ بالحالة غير المحفوظة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle App wird geschlossen und in LiveProcess neu gestartet. Nicht gespeicherter Zustand bleibt nicht erhalten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current app will close and restart in LiveProcess. Unsaved state will not be preserved."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La app actual se cerrará y se reiniciará en LiveProcess. El estado no guardado no se conservará."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'app actuelle va se fermer et redémarrer dans LiveProcess. L'état non enregistré ne sera pas conservé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'app corrente verrà chiusa e riavviata in LiveProcess. Lo stato non salvato non verrà conservato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のアプリを閉じてLiveProcessで再起動します。保存されていない状態は保持されません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 앱이 종료되고 LiveProcess에서 다시 시작됩니다. 저장되지 않은 상태는 유지되지 않습니다."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bieżąca aplikacja zostanie zamknięta i uruchomiona ponownie w LiveProcess. Niezapisany stan nie zostanie zachowany."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O app atual será fechado e reiniciado no LiveProcess. O estado não salvo não será preservado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущее приложение будет закрыто и перезапущено в LiveProcess. Несохраненное состояние не сохранится."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den aktuella appen stängs och startas om i LiveProcess. Osparat tillstånd bevaras inte."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçerli uygulama kapatılıp LiveProcess içinde yeniden başlatılacak. Kaydedilmemiş durum korunmayacak."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ứng dụng hiện tại sẽ đóng và khởi động lại trong LiveProcess. Trạng thái chưa lưu sẽ không được giữ lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的 App 将关闭并在 LiveProcess 中重新启动，未保存的状态不会保留。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前的 App 將關閉並在 LiveProcess 中重新啟動，未儲存的狀態不會保留。"
+          }
+        }
+      }
+    },
     "lc.multitask.copyPid" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1719,6 +1719,107 @@
         }
       }
     },
+    "lc.appList.jitlessCertificateRequiredIOS26" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يتطلب iOS 26 أو الأحدث وضع JITLess. يرجى استيراد الشهادة المستخدمة لتوقيع LiveContainer من الإعدادات قبل تشغيل التطبيقات."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unter iOS 26 oder neuer ist der JITLess-Modus erforderlich. Bitte importiere in den Einstellungen das Zertifikat, mit dem LiveContainer signiert wurde, bevor du Apps startest."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JITLess mode is required on iOS 26 or later. Please import the certificate used to sign LiveContainer in Settings before launching apps."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En iOS 26 o posterior se requiere el modo JITLess. Importa en Ajustes el certificado usado para firmar LiveContainer antes de abrir apps."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode JITLess est requis sous iOS 26 ou version ultérieure. Importez dans les réglages le certificat utilisé pour signer LiveContainer avant de lancer des apps."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Su iOS 26 o versioni successive è richiesta la modalità JITLess. Importa nelle impostazioni il certificato usato per firmare LiveContainer prima di avviare le app."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 26以降ではJITLessモードが必要です。アプリを起動する前に、設定でLiveContainerの署名に使用した証明書を読み込んでください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 26 이상에서는 JITLess 모드가 필요합니다. 앱을 실행하기 전에 설정에서 LiveContainer 서명에 사용한 인증서를 가져오세요."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Na iOS 26 lub nowszym wymagany jest tryb JITLess. Przed uruchomieniem aplikacji zaimportuj w ustawieniach certyfikat użyty do podpisania LiveContainer."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No iOS 26 ou posterior, o modo JITLess é necessário. Importe nos Ajustes o certificado usado para assinar o LiveContainer antes de abrir apps."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "На iOS 26 или новее требуется режим JITLess. Перед запуском приложений импортируйте в настройках сертификат, которым был подписан LiveContainer."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "På iOS 26 eller senare krävs JITLess-läge. Importera certifikatet som användes för att signera LiveContainer i inställningarna innan du startar appar."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 26 veya daha yenisinde JITLess modu gerekir. Uygulamaları başlatmadan önce Ayarlar'da LiveContainer'ı imzalamak için kullanılan sertifikayı içe aktarın."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 26 trở lên yêu cầu chế độ JITLess. Vui lòng nhập chứng chỉ dùng để ký LiveContainer trong Cài đặt trước khi chạy ứng dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 26 或更新版本需要使用免 JIT 模式。请先到 LiveContainer 设置中导入用于签署 LiveContainer 的证书，再启动 App。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS 26 或更新版本需要使用免 JIT 模式。請先到 LiveContainer 設定匯入用來簽署 LiveContainer 的憑證，再啟動 App。"
+          }
+        }
+      }
+    },
     "lc.appList.abortInstallation" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/TweakLoader/UIKit+GuestHooks.m
+++ b/TweakLoader/UIKit+GuestHooks.m
@@ -9,6 +9,48 @@ UIInterfaceOrientation LCOrientationLock = UIInterfaceOrientationUnknown;
 NSMutableArray<NSString*>* LCSupportedUrlSchemes = nil;
 BOOL launchURLProcessed = NO;
 
+static NSString * const LCPendingLiveProcessBundleIDKey = @"LCPendingLiveProcessBundleID";
+static NSString * const LCPendingLiveProcessDataUUIDKey = @"LCPendingLiveProcessDataUUID";
+static CFStringRef const LCActionButtonSwitchNotification = CFSTR("com.kdt.livecontainer.actionButtonSwitch");
+static const void *LCLaunchModeHomeBarCaptureViewKey = &LCLaunchModeHomeBarCaptureViewKey;
+static const NSTimeInterval LCLaunchModeHomeBarLongPressDuration = 0.65;
+static const CGFloat LCLaunchModeHomeBarExtraCaptureHeight = 6.0;
+static const CGFloat LCLaunchModeHomeBarMinimumCaptureHeight = 36.0;
+static const CGFloat LCLaunchModeHomeBarAllowableMovement = 22.0;
+
+@class LCLaunchModeSwitchGestureController;
+
+@interface LCLaunchModeHomeBarCaptureView : UIView
+@property(nonatomic, weak) LCLaunchModeSwitchGestureController *controller;
+@property(nonatomic) BOOL trackingHomeBarPress;
+@property(nonatomic) CGPoint initialTouchLocation;
+@property(nonatomic, copy) dispatch_block_t longPressBlock;
+- (void)cancelPendingLongPress;
+@end
+
+@interface LCLaunchModeSwitchGestureController : NSObject
+@property(nonatomic) BOOL showingAlert;
+@property(nonatomic) BOOL installed;
+@property(nonatomic) NSUInteger actionButtonInvocationCount;
+@property(nonatomic) CFAbsoluteTime lastActionButtonInvocationTime;
+@property(nonatomic) UIAlertController *confirmationAlert;
++ (instancetype)shared;
+- (void)install;
+- (void)handleActionButtonInvocation;
+- (void)handleHomeBarLongPressTimerFired;
+- (BOOL)confirmationAlertIsVisible;
+@end
+
+static void LCActionButtonSwitchNotificationCallback(CFNotificationCenterRef center,
+                                                     void *observer,
+                                                     CFNotificationName name,
+                                                     const void *object,
+                                                     CFDictionaryRef userInfo) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [LCLaunchModeSwitchGestureController.shared handleActionButtonInvocation];
+    });
+}
+
 __attribute__((constructor))
 static void UIKitGuestHooksInit() {
     if(!NSUserDefaults.lcGuestAppId) return;
@@ -19,6 +61,11 @@ static void UIKitGuestHooksInit() {
     swizzle(UIApplication.class, @selector(setDelegate:), @selector(hook_setDelegate:));
     swizzle(UIScene.class, @selector(scene:didReceiveActions:fromTransitionContext:), @selector(hook_scene:didReceiveActions:fromTransitionContext:));
     swizzle(UIScene.class, @selector(openURL:options:completionHandler:), @selector(hook_openURL:options:completionHandler:));
+    if(@available(iOS 16.0, *)) {
+        if(!NSUserDefaults.isLiveProcess && !NSUserDefaults.isSideStore) {
+            [LCLaunchModeSwitchGestureController.shared install];
+        }
+    }
     NSInteger LCOrientationLockDirection = [NSUserDefaults.guestAppInfo[@"LCOrientationLock"] integerValue];
     if(LCOrientationLockDirection != 0 && [UIDevice.currentDevice userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
         switch (LCOrientationLockDirection) {
@@ -150,6 +197,300 @@ void LCShowAlert(NSString* message) {
     [window.rootViewController presentViewController:alert animated:YES completion:nil];
     objc_setAssociatedObject(alert, @"window", window, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
+
+@implementation LCLaunchModeHomeBarCaptureView
+
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    if(self.hidden || !self.userInteractionEnabled || self.alpha < 0.01) {
+        return nil;
+    }
+    return [self pointInside:point withEvent:event] ? self : nil;
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self cancelPendingLongPress];
+    if(touches.count != 1 || event.allTouches.count != 1) {
+        return;
+    }
+
+    UITouch *touch = touches.anyObject;
+    self.initialTouchLocation = [touch locationInView:self];
+    self.trackingHomeBarPress = YES;
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_block_t block = dispatch_block_create(0, ^{
+        LCLaunchModeHomeBarCaptureView *strongSelf = weakSelf;
+        if(!strongSelf || !strongSelf.trackingHomeBarPress || !strongSelf.window) {
+            return;
+        }
+        strongSelf.trackingHomeBarPress = NO;
+        strongSelf.longPressBlock = nil;
+        [strongSelf.controller handleHomeBarLongPressTimerFired];
+    });
+    self.longPressBlock = block;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(LCLaunchModeHomeBarLongPressDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), block);
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    if(!self.trackingHomeBarPress) {
+        return;
+    }
+    if(event.allTouches.count != 1) {
+        [self cancelPendingLongPress];
+        return;
+    }
+
+    UITouch *touch = touches.anyObject;
+    CGPoint location = [touch locationInView:self];
+    CGFloat dx = location.x - self.initialTouchLocation.x;
+    CGFloat dy = location.y - self.initialTouchLocation.y;
+    CGFloat maximumDistance = LCLaunchModeHomeBarAllowableMovement * LCLaunchModeHomeBarAllowableMovement;
+    if(dx * dx + dy * dy > maximumDistance) {
+        [self cancelPendingLongPress];
+    }
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self cancelPendingLongPress];
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [self cancelPendingLongPress];
+}
+
+- (void)cancelPendingLongPress {
+    self.trackingHomeBarPress = NO;
+    if(self.longPressBlock) {
+        dispatch_block_cancel(self.longPressBlock);
+        self.longPressBlock = nil;
+    }
+}
+
+@end
+
+@implementation LCLaunchModeSwitchGestureController
+
++ (instancetype)shared {
+    static LCLaunchModeSwitchGestureController *controller;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        controller = [LCLaunchModeSwitchGestureController new];
+    });
+    return controller;
+}
+
+- (void)install {
+    if(self.installed) {
+        return;
+    }
+    self.installed = YES;
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(attachGestureToGuestWindows)
+                                               name:UIApplicationDidBecomeActiveNotification
+                                             object:nil];
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(),
+                                    NULL,
+                                    LCActionButtonSwitchNotificationCallback,
+                                    LCActionButtonSwitchNotification,
+                                    NULL,
+                                    CFNotificationSuspensionBehaviorDeliverImmediately);
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self attachGestureToGuestWindows];
+    });
+}
+
+- (void)attachGestureToGuestWindows {
+    for(UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if(![scene isKindOfClass:UIWindowScene.class]) {
+            continue;
+        }
+        for(UIWindow *window in ((UIWindowScene *)scene).windows) {
+            if(window.windowLevel != UIWindowLevelNormal) {
+                continue;
+            }
+            LCLaunchModeHomeBarCaptureView *captureView = objc_getAssociatedObject(window, LCLaunchModeHomeBarCaptureViewKey);
+            if(captureView) {
+                [window bringSubviewToFront:captureView];
+                continue;
+            }
+
+            captureView = [[LCLaunchModeHomeBarCaptureView alloc] initWithFrame:CGRectZero];
+            captureView.translatesAutoresizingMaskIntoConstraints = NO;
+            captureView.backgroundColor = UIColor.clearColor;
+            captureView.userInteractionEnabled = YES;
+            captureView.multipleTouchEnabled = NO;
+            captureView.exclusiveTouch = YES;
+            captureView.isAccessibilityElement = NO;
+            captureView.accessibilityElementsHidden = YES;
+            captureView.controller = self;
+
+            [window addSubview:captureView];
+            NSLayoutConstraint *topConstraint = [captureView.topAnchor constraintEqualToAnchor:window.safeAreaLayoutGuide.bottomAnchor constant:-LCLaunchModeHomeBarExtraCaptureHeight];
+            topConstraint.priority = UILayoutPriorityDefaultHigh;
+            [NSLayoutConstraint activateConstraints:@[
+                [captureView.leadingAnchor constraintEqualToAnchor:window.leadingAnchor],
+                [captureView.trailingAnchor constraintEqualToAnchor:window.trailingAnchor],
+                [captureView.bottomAnchor constraintEqualToAnchor:window.bottomAnchor],
+                [captureView.heightAnchor constraintGreaterThanOrEqualToConstant:LCLaunchModeHomeBarMinimumCaptureHeight],
+                topConstraint
+            ]];
+            objc_setAssociatedObject(window, LCLaunchModeHomeBarCaptureViewKey, captureView, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    }
+}
+
+- (void)handleHomeBarLongPressTimerFired {
+    if([self confirmationAlertIsVisible]) {
+        return;
+    }
+    UIImpactFeedbackGenerator *feedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+    [feedback impactOccurred];
+    [self presentSwitchConfirmation];
+}
+
+- (void)handleActionButtonInvocation {
+    CFAbsoluteTime now = CFAbsoluteTimeGetCurrent();
+    if(now - self.lastActionButtonInvocationTime > 8.0) {
+        self.actionButtonInvocationCount = 0;
+    }
+    self.lastActionButtonInvocationTime = now;
+    self.actionButtonInvocationCount += 1;
+    NSLog(@"[LC][LaunchModeSwitch] Action Button shortcut invocation %lu/3", (unsigned long)self.actionButtonInvocationCount);
+
+    if(self.actionButtonInvocationCount < 3) {
+        UIImpactFeedbackGenerator *feedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+        [feedback impactOccurred];
+        return;
+    }
+
+    self.actionButtonInvocationCount = 0;
+    [self presentSwitchConfirmation];
+}
+
+- (UIWindowScene *)activeWindowScene {
+    for(UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if([scene isKindOfClass:UIWindowScene.class] && scene.activationState == UISceneActivationStateForegroundActive) {
+            return (UIWindowScene *)scene;
+        }
+    }
+    for(UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if([scene isKindOfClass:UIWindowScene.class]) {
+            return (UIWindowScene *)scene;
+        }
+    }
+    return nil;
+}
+
+- (UIViewController *)topViewControllerFrom:(UIViewController *)viewController {
+    UIViewController *presentedViewController = viewController.presentedViewController;
+    if(presentedViewController && !presentedViewController.isBeingDismissed) {
+        return [self topViewControllerFrom:presentedViewController];
+    }
+    if([viewController isKindOfClass:UINavigationController.class]) {
+        return [self topViewControllerFrom:((UINavigationController *)viewController).visibleViewController];
+    }
+    if([viewController isKindOfClass:UITabBarController.class]) {
+        return [self topViewControllerFrom:((UITabBarController *)viewController).selectedViewController];
+    }
+    if([viewController isKindOfClass:UISplitViewController.class]) {
+        UIViewController *lastViewController = ((UISplitViewController *)viewController).viewControllers.lastObject;
+        if(lastViewController) {
+            return [self topViewControllerFrom:lastViewController];
+        }
+    }
+    return viewController;
+}
+
+- (void)presentSwitchConfirmation {
+    if([self confirmationAlertIsVisible] || UIApplication.sharedApplication.applicationState != UIApplicationStateActive) {
+        return;
+    }
+
+    NSString *bundleID = NSBundle.mainBundle.bundlePath.lastPathComponent;
+    NSString *dataUUID = [NSString stringWithUTF8String:getenv("HOME")].lastPathComponent;
+    if(bundleID.length == 0 || dataUUID.length == 0) {
+        return;
+    }
+
+    self.showingAlert = YES;
+    UIWindowScene *windowScene = [self activeWindowScene];
+    if(!windowScene) {
+        self.showingAlert = NO;
+        return;
+    }
+
+    UIWindow *guestWindow = windowScene.keyWindow;
+    if(!guestWindow) {
+        for(UIWindow *window in windowScene.windows) {
+            if(window.windowLevel == UIWindowLevelNormal && !window.hidden) {
+                guestWindow = window;
+                break;
+            }
+        }
+    }
+    UIViewController *presenter = [self topViewControllerFrom:guestWindow.rootViewController];
+    if(!presenter || !presenter.view.window) {
+        self.showingAlert = NO;
+        return;
+    }
+
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"LiveContainer"
+                                                                   message:@"lc.launchMode.switchToLiveProcessMessage".loc
+                                                            preferredStyle:UIAlertControllerStyleActionSheet];
+    self.confirmationAlert = alert;
+
+    __weak typeof(self) weakSelf = self;
+    [alert addAction:[UIAlertAction actionWithTitle:@"lc.launchMode.switchToLiveProcess".loc
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *action) {
+        NSUserDefaults *defaults = NSUserDefaults.lcUserDefaults;
+        [defaults setObject:bundleID forKey:LCPendingLiveProcessBundleIDKey];
+        [defaults setObject:dataUUID forKey:LCPendingLiveProcessDataUUIDKey];
+        [defaults removeObjectForKey:@"selected"];
+        [defaults removeObjectForKey:@"selectedContainer"];
+        [defaults synchronize];
+        NSLog(@"[LC][LaunchModeSwitch] stopping LiveContainer guest %@ to relaunch container %@ in LiveProcess", bundleID, dataUUID);
+        [weakSelf finishSwitchConfirmation];
+        [NSClassFromString(@"LCSharedUtils") launchToGuestApp];
+    }]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"lc.common.cancel".loc
+                                              style:UIAlertActionStyleCancel
+                                            handler:^(UIAlertAction *action) {
+        [weakSelf finishSwitchConfirmation];
+    }]];
+
+    UIPopoverPresentationController *popoverController = alert.popoverPresentationController;
+    if(popoverController) {
+        popoverController.sourceView = presenter.view;
+        popoverController.sourceRect = CGRectMake(CGRectGetMidX(presenter.view.bounds),
+                                                   CGRectGetMaxY(presenter.view.bounds) - 1,
+                                                   1,
+                                                   1);
+        popoverController.permittedArrowDirections = 0;
+    }
+
+    [presenter presentViewController:alert animated:YES completion:nil];
+}
+
+- (BOOL)confirmationAlertIsVisible {
+    UIAlertController *alert = self.confirmationAlert;
+    if(!alert) {
+        self.showingAlert = NO;
+        return NO;
+    }
+    if(alert.presentingViewController || alert.isBeingPresented || alert.view.window) {
+        return YES;
+    }
+    [self finishSwitchConfirmation];
+    return NO;
+}
+
+- (void)finishSwitchConfirmation {
+    self.confirmationAlert = nil;
+    self.showingAlert = NO;
+}
+
+@end
 
 void LCShowAppNotFoundAlert(NSString* bundleId) {
     LCShowAlert([@"lc.guestTweak.error.bundleNotFound %@" localizeWithFormat: bundleId]);


### PR DESCRIPTION
## Issue

Apps that support Picture in Picture may not work correctly when launched in LiveProcess mode.  
This PR adds a way for users to switch a guest app between LiveContainer and LiveProcess launch modes.

It also adds a preflight check for missing JITLess certificates on iOS 26 or later.

## Changes

- Add a launch mode submenu for guest apps:
  - Run in LiveContainer
  - Run in LiveProcess
- Add an in-guest switch from LiveContainer to LiveProcess.
  - Users can long-press the Home Bar area to open the switch confirmation menu.
- Add an option to switch from LiveProcess back to LiveContainer.
- Add an App Intent / Shortcuts action for switching to LiveProcess.
- Add localized strings for the new launch mode UI.
- Add an iOS 26+ preflight check to prevent launching guest apps without an imported signing certificate.
  - Instead of failing after the guest app starts launching, LiveContainer now shows a clear error before launch.
 
---

##### Cowork with Codex. :)