### PR TITLE
chore: update readme to match the new license

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Open Xcode, edit `DEVELOPMENT_TEAM[config=Debug]` in `xcconfigs/Global.xcconfig`
 - Use ChOma instead of custom MachO parser
 
 ## License
-[Apache License 2.0](https://github.com/khanhduytran0/LiveContainer/blob/main/LICENSE)
+[GNU Affero General Public License v3.0](https://github.com/khanhduytran0/LiveContainer/blob/main/LICENSE)
 
 ## Credits
 - [xpn's blogpost: Restoring Dyld Memory Loading](https://blog.xpnsec.com/restoring-dyld-memory-loading)


### PR DESCRIPTION
when your license was updated 10 months ago the readme wasnt updated to match it