### PR TITLE
Add App Shortcut to open guest apps from Spotlight

### DIFF
--- a/.github/build_github.sh
+++ b/.github/build_github.sh
@@ -56,9 +56,12 @@ cp ./.github/sidelc/LCAppInfo.plist ./Payload/LiveContainer.app/Frameworks/SideS
 # copy intents
 cp ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/Intents.intentdefinition ./Payload/LiveContainer.app/
 cp ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/ViewApp.intentdefinition ./Payload/LiveContainer.app/
-cp -r ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/Metadata.appintents ./Payload/LiveContainer.app/Metadata.appintents
-sed -i '' 's/9SideStore20RefreshAllAppsIntentV/16SideStoreSupport20RefreshAllAppsIntentV/g' ./Payload/LiveContainer.app/Metadata.appintents/extract.actionsdata
-sed -i '' 's/9SideStore26RefreshAllAppsWidgetIntentV/16SideStoreSupport26RefreshAllAppsWidgetIntentV/g' ./Payload/LiveContainer.app/Metadata.appintents/extract.actionsdata
+# LiveContainer's own build phase already published its App Shortcut metadata
+# to this slot, and a bundle only has one. Merge SideStore's actions in rather
+# than copying over it, which would nest the directory and drop one side.
+python3 ./.github/merge_appintents_metadata.py \
+  ./Payload/LiveContainer.app/Metadata.appintents/extract.actionsdata \
+  ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/Metadata.appintents/extract.actionsdata
 
 # AltWidgetExtension
 mv ./Payload/LiveContainer.app/Frameworks/SideStoreApp.framework/PlugIns/AltWidgetExtension.appex ./Payload/LiveContainer.app/PlugIns/LiveWidgetExtension.appex

--- a/.github/merge_appintents_metadata.py
+++ b/.github/merge_appintents_metadata.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Merge SideStore's App Intents metadata into LiveContainer's.
+
+An app bundle has exactly one Metadata.appintents slot, and both LiveContainer
+(App Shortcuts for guest apps) and the grafted SideStore now want it. Copying
+one over the other loses the loser, so merge instead.
+
+An app may also declare only one AppShortcutsProvider, since the format carries
+a single autoShortcutProviderMangledName. LiveContainer's wins because its
+shortcut has a dynamic entity parameter that needs updateAppShortcutParameters();
+SideStore's two are static refresh actions, so they lose their Siri phrases but
+keep their actions in the Shortcuts app.
+
+Only the actions SideStoreSupport.framework actually implements are imported,
+with their module names rewritten. InstallIPAIntent exists in SideStore.app but
+not in SideStoreSupport, so importing it would advertise an action that cannot
+resolve.
+
+Usage: merge_appintents_metadata.py <app-root actionsdata> <sidestore actionsdata>
+"""
+import json
+import sys
+
+MINE, THEIRS = sys.argv[1], sys.argv[2]
+
+RENAMES = {
+    "9SideStore20RefreshAllAppsIntentV": "16SideStoreSupport20RefreshAllAppsIntentV",
+    "9SideStore26RefreshAllAppsWidgetIntentV": "16SideStoreSupport26RefreshAllAppsWidgetIntentV",
+}
+IMPORT_ACTIONS = {"RefreshAllIntent", "RefreshAllAppsWidgetIntent"}
+
+
+def rewrite(obj):
+    if isinstance(obj, str):
+        for old, new in RENAMES.items():
+            obj = obj.replace(old, new)
+        return obj
+    if isinstance(obj, list):
+        return [rewrite(x) for x in obj]
+    if isinstance(obj, dict):
+        return {k: rewrite(v) for k, v in obj.items()}
+    return obj
+
+
+mine = json.load(open(MINE))
+theirs = json.load(open(THEIRS))
+
+imported = []
+for name, action in theirs.get("actions", {}).items():
+    if name not in IMPORT_ACTIONS or name in mine["actions"]:
+        continue
+    mine["actions"][name] = rewrite(action)
+    imported.append(name)
+
+json.dump(mine, open(MINE, "w"), separators=(",", ":"))
+print(f"merged SideStore actions into app metadata: {sorted(imported)}")
+print(f"kept App Shortcut provider: {sorted(mine['actions'])}")

--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -682,6 +682,7 @@
 				17413FC12D9C0BAE00F3F928 /* Embed Frameworks */,
 				17D4DA692D9C495E008E7396 /* Run Script */,
 				17CAE6202F230449008B1977 /* Embed ExtensionKit Extensions */,
+				17AA00022F900002008B1977 /* Publish App Intents metadata */,
 			);
 			buildRules = (
 			);
@@ -949,6 +950,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nINFO_PLIST=\"${TARGET_BUILD_DIR}\"/\"${INFOPLIST_PATH}\"\n\n# Get current Git branch and commit hash\nCONFIG_BRANCH=$(git rev-parse --abbrev-ref HEAD)\nCONFIG_COMMIT=$(git log -1 --format=%h)\n\n# Combine values into a version info string\nLCVersionInfo=\"$CONFIGURATION ($CONFIG_BRANCH/$CONFIG_COMMIT)\"\n\n/usr/libexec/PlistBuddy -c \"Add :LCVersionInfo string $LCVersionInfo\" \"${INFO_PLIST}\"\ncp -n -r \"$SRCROOT\"/Resources/*.lproj \"$TARGET_BUILD_DIR/$CONTENTS_FOLDER_PATH\"\necho 1\n";
+		};
+		17AA00022F900002008B1977 /* Publish App Intents metadata */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Frameworks/LiveContainerSwiftUI.framework/Metadata.appintents/extract.actionsdata",
+			);
+			name = "Publish App Intents metadata";
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(CONTENTS_FOLDER_PATH)/Metadata.appintents/extract.actionsdata",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${ACTION}\" = \"indexbuild\" ]; then exit 0; fi\n# The App Shortcut's intent must be instantiable in the APP process: iOS looks\n# for the Swift type there, not in an extension. LiveContainerSwiftUI.framework\n# is only ever dlopen'd (LCBootstrap.m), never linked, so Xcode's automatic\n# App Intents metadata aggregation cannot see it and we publish it by hand.\nAPP=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}\"\nSRC=\"$APP/Frameworks/LiveContainerSwiftUI.framework/Metadata.appintents\"\nif [ ! -d \"$SRC\" ]; then\n  echo \"error: LiveContainerSwiftUI Metadata.appintents not found; App Shortcuts would silently not work\"\n  exit 1\nfi\nrm -rf \"$APP/Metadata.appintents\"\ncp -R \"$SRC\" \"$APP/Metadata.appintents\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/LiveContainerSwiftUI/Models/AppShortcuts/LCAppShortcuts.swift
+++ b/LiveContainerSwiftUI/Models/AppShortcuts/LCAppShortcuts.swift
@@ -1,0 +1,32 @@
+//
+//  LCAppShortcuts.swift
+//  LiveContainer
+//
+//  Vends one parameterised App Shortcut covering every indexed guest app.
+//  This is what makes guest apps show up in Spotlight and Siri with no
+//  per-app setup: no shortcut to build, no launch URL to paste, no icon to
+//  save, no configuration profile to install.
+//
+//  Every phrase has to contain the app name token, hence `\(.applicationName)`
+//  in all of them.
+//
+
+import AppIntents
+
+@available(iOS 17.0, *)
+struct LCAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: LCOpenGuestAppIntent(),
+            phrases: [
+                "Open \(\.$app) in \(.applicationName)",
+                "Launch \(\.$app) in \(.applicationName)",
+                "Run \(\.$app) in \(.applicationName)",
+                "Start \(\.$app) in \(.applicationName)",
+                "\(.applicationName) \(\.$app)"
+            ],
+            shortTitle: "Open App",
+            systemImageName: "square.stack.3d.up.fill"
+        )
+    }
+}

--- a/LiveContainerSwiftUI/Models/AppShortcuts/LCGuestAppCatalog.swift
+++ b/LiveContainerSwiftUI/Models/AppShortcuts/LCGuestAppCatalog.swift
@@ -1,0 +1,170 @@
+//
+//  LCGuestAppCatalog.swift
+//  LiveContainerSwiftUI
+//
+//  Supplies the guest apps that back the App Shortcut's app parameter, and
+//  tells the system when that set changes.
+//
+//  The App Shortcut's intent has to live in this framework, because iOS
+//  instantiates it in the app process rather than in an extension. That means
+//  the query runs here too and can read the live app list directly.
+//
+
+import AppIntents
+import Combine
+import Foundation
+import UIKit
+
+final class LCGuestAppCatalog {
+    static let shared = LCGuestAppCatalog()
+
+    /// Set this in the shared defaults to keep guest apps out of Spotlight and Siri.
+    static let disableKey = "LCDisableAppShortcuts"
+
+    private var cancellables = Set<AnyCancellable>()
+
+    /// Watches the app list the same way `LCAppSortManager` does, so every
+    /// install, delete and visibility change re-indexes without a call at each
+    /// mutation site.
+    private init() {
+        DataManager.shared.model.$apps
+            .sink { _ in Self.refreshShortcutParameters() }
+            .store(in: &cancellables)
+    }
+
+    /// Touching the singleton starts the observation; the initial `@Published`
+    /// value also refreshes once at launch, covering apps that changed while
+    /// LiveContainer was not running.
+    func start() {}
+
+    /// Tells the system the parameter values may have changed. Without this iOS
+    /// never enumerates the entities, so the App Shortcut is indexed with an
+    /// empty value set and nothing matches in Spotlight.
+    static func refreshShortcutParameters() {
+        guard !LCUtils.appGroupUserDefault.bool(forKey: disableKey) else { return }
+        if #available(iOS 17.0, *) {
+            LCAppShortcuts.updateAppShortcutParameters()
+        }
+    }
+
+    // MARK: - Reading the app list
+
+    /// Hidden apps are never listed. `sharedModel.apps` already excludes them,
+    /// and `hiddenApps` is deliberately not consulted, so a hidden app cannot
+    /// leak into a system-wide index.
+    @available(iOS 17.0, *)
+    @MainActor
+    static func entities() -> [LCGuestApp] {
+        guard !LCUtils.appGroupUserDefault.bool(forKey: disableKey) else { return [] }
+
+        let models = DataManager.shared.model.apps
+        var out: [LCGuestApp] = []
+        out.reserveCapacity(models.count)
+
+        for model in models {
+            let info = model.appInfo
+            guard let bundleFolderName = info.relativeBundlePath, !bundleFolderName.isEmpty else { continue }
+            let displayName = info.displayName() ?? bundleFolderName
+            let bundleIdentifier = info.bundleIdentifier()
+            let icon = iconURL(for: model)
+
+            func entity(_ container: LCContainer?) -> LCGuestApp {
+                LCGuestApp(displayName: displayName,
+                           containerName: container?.name,
+                           bundleFolderName: bundleFolderName,
+                           containerFolderName: container?.folderName,
+                           searchTerms: searchTerms(displayName: displayName,
+                                                    bundleIdentifier: bundleIdentifier,
+                                                    containerName: container?.name),
+                           iconURL: icon)
+            }
+
+            out.append(entity(nil))
+            // Multi-container apps get one extra row per container, so someone
+            // running two accounts of the same app can reach either directly.
+            guard model.uiContainers.count > 1 else { continue }
+            out.append(contentsOf: model.uiContainers.map(entity))
+        }
+        return out
+    }
+
+    /// Builds only the requested entities, so resolving the parameter before a
+    /// launch does not rebuild the whole catalog.
+    @available(iOS 17.0, *)
+    @MainActor
+    static func entities(withIDs ids: Set<String>) -> [LCGuestApp] {
+        guard !ids.isEmpty else { return [] }
+        let wantedBundles = Set(ids.map { $0.split(separator: "|", maxSplits: 1)[0] })
+        return entities(matchingBundleFolderNames: wantedBundles).filter { ids.contains($0.id) }
+    }
+
+    @available(iOS 17.0, *)
+    @MainActor
+    private static func entities(matchingBundleFolderNames wanted: Set<Substring>) -> [LCGuestApp] {
+        entities().filter { wanted.contains(Substring($0.bundleFolderName)) }
+    }
+
+    // MARK: - Icons
+
+    /// `DisplayRepresentation.Image` wants a URL, so icons are rendered to the
+    /// caches directory once and reused.
+    @MainActor
+    private static func iconURL(for model: LCAppModel) -> URL? {
+        guard let bundleFolderName = model.appInfo.relativeBundlePath else { return nil }
+        let url = iconDirectory.appendingPathComponent("\(sanitize(bundleFolderName)).png")
+        if FileManager.default.fileExists(atPath: url.path) { return url }
+
+        guard let icon = model.appInfo.iconIsDarkIcon(false),
+              let data = resized(icon, to: 180)?.pngData() else { return nil }
+        do {
+            try FileManager.default.createDirectory(at: iconDirectory, withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            NSLog("[LC] could not cache app shortcut icon: \(error)")
+            return nil
+        }
+        return url
+    }
+
+    private static let iconDirectory = FileManager.default
+        .urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        .appendingPathComponent("AppShortcutIcons", isDirectory: true)
+
+    // MARK: - Helpers
+
+    private static func searchTerms(displayName: String,
+                                    bundleIdentifier: String?,
+                                    containerName: String?) -> [String] {
+        var terms: Set<String> = [displayName.lcFolded]
+        // Individual words, so "Prime Video" matches on "video".
+        for word in displayName.split(whereSeparator: { $0 == " " || $0 == "-" || $0 == "_" }) {
+            terms.insert(String(word).lcFolded)
+        }
+        if let bundleIdentifier {
+            terms.insert(bundleIdentifier.lcFolded)
+            if let last = bundleIdentifier.split(separator: ".").last {
+                terms.insert(String(last).lcFolded)
+            }
+        }
+        if let containerName {
+            terms.insert(containerName.lcFolded)
+        }
+        terms.remove("")
+        return Array(terms)
+    }
+
+    private static func sanitize(_ s: String) -> String {
+        String(s.map { $0.isLetter || $0.isNumber ? $0 : "_" })
+    }
+
+    private static func resized(_ image: UIImage, to side: CGFloat) -> UIImage? {
+        let size = CGSize(width: side, height: side)
+        if image.size == size { return image }
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 1
+        format.opaque = false
+        return UIGraphicsImageRenderer(size: size, format: format).image { _ in
+            image.draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/LiveContainerSwiftUI/Models/AppShortcuts/LCGuestAppEntity.swift
+++ b/LiveContainerSwiftUI/Models/AppShortcuts/LCGuestAppEntity.swift
@@ -1,0 +1,101 @@
+//
+//  LCGuestAppEntity.swift
+//  LiveContainerSwiftUI
+//
+//  Exposes each guest app as an AppEntity so the system can enumerate them,
+//  match them against typed or spoken text, and offer one Spotlight and Siri
+//  row per app without the user hand-building a shortcut for each one.
+//
+
+import AppIntents
+import Foundation
+
+extension String {
+    var lcFolded: String {
+        folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+    }
+}
+
+@available(iOS 17.0, *)
+struct LCGuestApp: AppEntity {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "App")
+    }
+
+    static var defaultQuery = LCGuestAppQuery()
+
+    var displayName: String
+    var containerName: String?
+    var bundleFolderName: String
+    var containerFolderName: String?
+    var searchTerms: [String]
+    var iconURL: URL?
+
+    /// Derived rather than stored, so it cannot drift from the fields it names.
+    var id: String {
+        containerFolderName.map { "\(bundleFolderName)|\($0)" } ?? bundleFolderName
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        // Only apps with more than one container carry a container name, so the
+        // subtitle stays empty in the common case instead of repeating itself.
+        let subtitle: LocalizedStringResource? = containerName
+            .flatMap { $0.isEmpty ? nil : "\($0)" }
+        return DisplayRepresentation(title: "\(displayName)",
+                                     subtitle: subtitle,
+                                     image: iconURL.map { .init(url: $0) })
+    }
+
+    /// The `livecontainer-launch` URL for this app, minus the scheme, which
+    /// depends on which container ends up hosting it.
+    var launchURLComponents: URLComponents {
+        var components = URLComponents()
+        components.host = "livecontainer-launch"
+        var items = [URLQueryItem(name: "bundle-name", value: bundleFolderName)]
+        if let containerFolderName {
+            items.append(URLQueryItem(name: "container-folder-name", value: containerFolderName))
+        }
+        components.queryItems = items
+        return components
+    }
+}
+
+// EnumerableEntityQuery matters here, not just EntityStringQuery: a
+// parameterised App Shortcut needs the system to be able to enumerate every
+// possible value of the parameter up front, otherwise it indexes the shortcut
+// with an empty value set and nothing matches in Spotlight.
+@available(iOS 17.0, *)
+struct LCGuestAppQuery: EnumerableEntityQuery, EntityStringQuery {
+    func allEntities() async throws -> [LCGuestApp] {
+        await MainActor.run { LCGuestAppCatalog.entities() }
+    }
+
+    func entities(for identifiers: [String]) async throws -> [LCGuestApp] {
+        let ids = Set(identifiers)
+        return await MainActor.run { LCGuestAppCatalog.entities(withIDs: ids) }
+    }
+
+    func entities(matching string: String) async throws -> [LCGuestApp] {
+        let needle = string.lcFolded
+        guard !needle.isEmpty else { return try await allEntities() }
+
+        // Rank prefix matches above substring matches so typing "tik" puts
+        // TikTok first rather than something that merely contains "tik".
+        // searchTerms always contains the folded display name, so the name does
+        // not need checking separately except for the exact case.
+        var exact: [LCGuestApp] = []
+        var prefix: [LCGuestApp] = []
+        var contains: [LCGuestApp] = []
+
+        for app in try await allEntities() {
+            if app.displayName.lcFolded == needle {
+                exact.append(app)
+            } else if app.searchTerms.contains(where: { $0.hasPrefix(needle) }) {
+                prefix.append(app)
+            } else if app.searchTerms.contains(where: { $0.contains(needle) }) {
+                contains.append(app)
+            }
+        }
+        return exact + prefix + contains
+    }
+}

--- a/LiveContainerSwiftUI/Models/AppShortcuts/LCOpenGuestAppIntent.swift
+++ b/LiveContainerSwiftUI/Models/AppShortcuts/LCOpenGuestAppIntent.swift
@@ -1,0 +1,87 @@
+//
+//  LCOpenGuestAppIntent.swift
+//  LiveContainerSwiftUI
+//
+//  The entity-backed sibling of `LaunchAppExtension`. Same idea, but the app is
+//  picked from the catalog instead of being pasted in as a URL, which is what
+//  lets the system vend one App Shortcut covering every guest app.
+//
+//  This deliberately lives in LiveContainerSwiftUI rather than in
+//  LaunchAppExtension. iOS instantiates an App Shortcut's intent in the *app*
+//  process, not in the extension, so a type compiled only into the extension
+//  fails with "the type with this mangled name does not exist in the process's
+//  memory space". SideStore's intents work in the combined build for exactly
+//  this reason: they resolve into SideStoreSupport.framework, which is loaded
+//  into the app. This framework is too.
+//
+//  Because we are already inside LiveContainer when this runs, there is no need
+//  for LaunchAppExtension's cross-process trick. We use LiveContainer's own
+//  launch path: write the LCLaunchExtension* keys into the shared app group and
+//  open the target container's URL scheme. LCBootstrap.m picks those up on
+//  launch (within a 3 second window) and loads the guest app directly.
+//
+
+import AppIntents
+import Foundation
+import UIKit
+
+@available(iOS 17.0, *)
+struct LCOpenGuestAppIntent: AppIntent {
+    static var title: LocalizedStringResource { "Open App in LiveContainer" }
+    static var description: IntentDescription {
+        IntentDescription("Opens an app installed in LiveContainer. Apps appear here automatically, so there is no launch URL to copy.")
+    }
+
+    // Must be true. An intent running in the background cannot call
+    // UIApplication.open(), so the tap silently does nothing. OpenURLIntent
+    // would avoid needing the foreground but is iOS 18+.
+    static var openAppWhenRun: Bool { true }
+
+    @Parameter(title: "App")
+    var app: LCGuestApp
+
+    init() {}
+
+    func perform() async throws -> some IntentResult {
+        let defaults = LCUtils.appGroupUserDefault
+
+        // Prefer a container already running this app's data folder, otherwise
+        // take the first free LiveContainer, otherwise fall back to the primary
+        // one and let it sort the conflict out.
+        var schemeToLaunch = "livecontainer"
+        if var running = LCSharedUtils.getContainerUsingLCScheme(withFolderName: app.containerFolderName) {
+            if running.hasSuffix("liveprocess") {
+                running = (running as NSString).deletingPathExtension
+            }
+            schemeToLaunch = running
+        } else {
+            LCUtils.forEachInstalledLC(isFree: true) { free, shouldBreak in
+                schemeToLaunch = free
+                shouldBreak = true
+            }
+        }
+
+        defaults.set(schemeToLaunch, forKey: "LCLaunchExtensionScheme")
+        defaults.set(app.bundleFolderName, forKey: "LCLaunchExtensionBundleID")
+        if let container = app.containerFolderName {
+            defaults.set(container, forKey: "LCLaunchExtensionContainerName")
+        } else {
+            defaults.removeObject(forKey: "LCLaunchExtensionContainerName")
+        }
+        // LCBootstrap rejects anything older than 3 seconds, so this has to be
+        // the last thing set before the open.
+        defaults.set(Date.now, forKey: "LCLaunchExtensionLaunchDate")
+
+        var components = app.launchURLComponents
+        components.scheme = schemeToLaunch
+        guard let url = components.url else {
+            throw "Could not build a launch URL for \(app.displayName)."
+        }
+
+        // We are foregrounded by now, so this is allowed. The URL goes through
+        // LCTabView.dispatchURL, the same path a web clip or the old Launch App
+        // shortcut uses, which is well tested.
+        await UIApplication.shared.open(url)
+        return .result()
+    }
+}

--- a/LiveContainerSwiftUI/Views/LCTabView.swift
+++ b/LiveContainerSwiftUI/Views/LCTabView.swift
@@ -87,6 +87,9 @@ struct LCTabView: View {
             }
         }
         .task {
+            // Starts observing the app list so the App Shortcut's app
+            // parameter is re-indexed whenever apps change.
+            LCGuestAppCatalog.shared.start()
             closeDuplicatedWindow()
             checkLastLaunchError()
             checkTeamId()

--- a/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/Settings/LCSettingsView.swift
@@ -51,6 +51,7 @@ struct LCSettingsView: View {
     @AppStorage("LCOpenWebPageWithoutAsking") var silentOpenWebPage = false
     @AppStorage("LCDontSignApp", store: LCUtils.appGroupUserDefault) var dontSignApp = false
     @AppStorage("LCStrictHiding", store: LCUtils.appGroupUserDefault) var strictHiding = false
+    @AppStorage(LCGuestAppCatalog.disableKey, store: LCUtils.appGroupUserDefault) var disableAppShortcuts = false
     @AppStorage("dynamicColors", store: LCUtils.appGroupUserDefault) var dynamicColors = true
     @AppStorage("darkModeIcon", store: LCUtils.appGroupUserDefault) var darkModeIcon = false
     
@@ -252,6 +253,22 @@ struct LCSettingsView: View {
                     }
                 }
                 
+                Section {
+                    Toggle(isOn: Binding(
+                        get: { !disableAppShortcuts },
+                        set: { newValue in
+                            disableAppShortcuts = !newValue
+                            // Republish immediately so turning this off clears
+                            // the index instead of leaving stale entries behind.
+                            LCGuestAppCatalog.refreshShortcutParameters()
+                        }
+                    )) {
+                        Text("lc.settings.appShortcuts".loc)
+                    }
+                } footer: {
+                    Text("lc.settings.appShortcutsDesc".loc)
+                }
+
                 Section {
                     Toggle(isOn: $dontSignApp) {
                         Text("lc.settings.dontSign".loc)

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -19361,6 +19361,28 @@
         }
       }
     },
+    "lc.settings.appShortcuts" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Apps in Spotlight and Siri"
+          }
+        }
+      }
+    },
+    "lc.settings.appShortcutsDesc" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lets you open an app in LiveContainer straight from Spotlight search or by asking Siri, with no shortcut to build and no home screen icon to add. Hidden apps are never listed."
+          }
+        }
+      }
+    },
     "lc.settings.autoEndPiP" : {
       "extractionState" : "stale",
       "localizations" : {


### PR DESCRIPTION
## What

Adds one parameterised App Shortcut to LiveContainer. Its app parameter enumerates the installed guest apps, so you can type a few letters in Spotlight, tap the result, and the guest app opens. Siri phrases such as "Open TikTok in LiveContainer" work as well. Apps appear as soon as they are installed, with no per-app setup.

Hidden apps are never listed. Settings has a toggle to turn the whole thing off.

## Why

Today, reaching a guest app from outside LiveContainer means building a Shortcut and pasting a Launch URL, saving an icon, or installing a web clip profile, once per app.

This is not the per-app extension registration that was declined in #245 and #1117. There is exactly one `AppShortcut`, declared by LiveContainer itself:

- No app extension is registered per guest app, and no additional App IDs are used.
- Nothing is registered at runtime, so an AltStore update has nothing to clear. The metadata is static in the bundle and the app list is resolved by a query.
- Launching reuses the existing `LCLaunchExtension*` keys and the `LCBootstrap` path, so there is no new code-level glue between LiveContainer and guest apps.

Related: #1213, #1209.

## How it works

- `LCGuestApp` is an `AppEntity`; `LCGuestAppQuery` enumerates guest apps from the live app list.
- The entity, query, intent and provider live in `LiveContainerSwiftUI` rather than in `LaunchAppExtension`. iOS instantiates an App Shortcut's intent in the **app** process, so a type compiled only into the extension fails with "the type with this mangled name does not exist in the process's memory space". SideStore's intents resolve for the same reason, into `SideStoreSupport.framework`.
- A Run Script phase publishes that framework's `Metadata.appintents` to the app bundle root. `LiveContainerSwiftUI.framework` is only ever `dlopen`'d in `LCBootstrap.m`, never linked, so Xcode's automatic App Intents metadata aggregation cannot see it and there is no build setting that fixes this.
- The catalog observes `DataManager.shared.model.$apps` with Combine, in the same shape as `LCAppSortManager`, so the parameter re-indexes when apps change.

Requires iOS 17 for `EnumerableEntityQuery`. Without the enumerable capability the system indexes the shortcut with an empty value set and nothing matches in Spotlight.

## How to verify

1. Build and install, then open LiveContainer once.
2. Open Shortcuts, add the "Open App in LiveContainer" action, and tap its **App** parameter. The installed guest apps should be listed with their icons.
3. Swipe down on the Home Screen and type the first few letters of a guest app name. Tap the result; the app should launch.
4. Ask Siri to "Open &lt;app&gt; in LiveContainer".
5. Hide an app in LiveContainer and confirm it disappears from Spotlight.

Tested on iPhone 17 Pro Max, iOS 26.6, with the LiveContainer+SideStore build. I have not tested on iPad, on iOS 17 or 18, or with LiveContainer 2 as the primary container.

## Open question

An app bundle has a single `Metadata.appintents` slot, and only one `AppShortcutsProvider` per app is allowed. In the `+SideStore` build this collides with SideStore's intents.

`build_github.sh` previously copied SideStore's metadata into that slot. Now that the build phase fills it first, that copy would nest the directory and the two `sed` calls after it would silently do nothing, dropping SideStore's actions. I have added `.github/merge_appintents_metadata.py` to merge instead: LiveContainer's App Shortcut keeps the provider slot, SideStore keeps its Shortcuts actions but loses its two Siri phrases.

That trade is my choice, not an obvious one. Tell me if you would rather have it the other way, or kept out of the combined build entirely.

## Out of scope

- `perform()` repeats the launch sequence in `LCAppModel.runApp`. Two further copies live in `ShareExtension` and `LaunchAppExtension`, which cannot use a `LiveContainerSwiftUI` helper, so I left the extraction alone rather than guess at the shape you want.
- Widgets and Control Center controls are unchanged.
- Only English strings are added, on the assumption that Crowdin owns the rest.
