### PR TITLE
Feature: Support import of deb-based tweaks in LiveContainer

### DIFF
--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		174140F52D9C1C9B00F3F928 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				DebPathRedirect.m,
 				DocumentPicker.m,
 				Notification.m,
 				TweakLoader.m,
@@ -226,6 +227,13 @@
 				src/litehook.c,
 			);
 			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
+		};
+		C4334165EF1E1B866767BAD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				src/litehook.c,
+			);
+			target = 174140392D9C0D0000F3F928 /* TweakLoader */;
 		};
 		17CAE6252F230449008B1977 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -318,7 +326,7 @@
 		174140162D9C0C1B00F3F928 /* TweakLoader */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (174140F52D9C1C9B00F3F928 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TweakLoader; sourceTree = "<group>"; };
 		174140552D9C0D6D00F3F928 /* ZSign */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ZSign; sourceTree = "<group>"; };
 		174140AE2D9C0F4100F3F928 /* TestJITLess */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TestJITLess; sourceTree = "<group>"; };
-		17780D3B2E1C02420077E636 /* litehook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17780E512E1C039D0077E636 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = litehook; sourceTree = "<group>"; };
+		17780D3B2E1C02420077E636 /* litehook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17780E512E1C039D0077E636 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C4334165EF1E1B866767BAD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = litehook; sourceTree = "<group>"; };
 		17B0F8452DE16FE4008110EA /* xcconfigs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = xcconfigs; sourceTree = "<group>"; };
 		17CAE6182F230449008B1977 /* LaunchAppExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17CAE6252F230449008B1977 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LaunchAppExtension; sourceTree = "<group>"; };
 		17E23DE02F443A9300C55733 /* ShareExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17E23DED2F443A9300C55733 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ShareExtension; sourceTree = "<group>"; };

--- a/LiveContainer.xcodeproj/project.pbxproj
+++ b/LiveContainer.xcodeproj/project.pbxproj
@@ -228,13 +228,6 @@
 			);
 			target = E1292BD52DCA3B660065E12D /* LiveContainerShared */;
 		};
-		C4334165EF1E1B866767BAD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				src/litehook.c,
-			);
-			target = 174140392D9C0D0000F3F928 /* TweakLoader */;
-		};
 		17CAE6252F230449008B1977 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -326,7 +319,7 @@
 		174140162D9C0C1B00F3F928 /* TweakLoader */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (174140F52D9C1C9B00F3F928 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TweakLoader; sourceTree = "<group>"; };
 		174140552D9C0D6D00F3F928 /* ZSign */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ZSign; sourceTree = "<group>"; };
 		174140AE2D9C0F4100F3F928 /* TestJITLess */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TestJITLess; sourceTree = "<group>"; };
-		17780D3B2E1C02420077E636 /* litehook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17780E512E1C039D0077E636 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, C4334165EF1E1B866767BAD4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = litehook; sourceTree = "<group>"; };
+		17780D3B2E1C02420077E636 /* litehook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17780E512E1C039D0077E636 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = litehook; sourceTree = "<group>"; };
 		17B0F8452DE16FE4008110EA /* xcconfigs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = xcconfigs; sourceTree = "<group>"; };
 		17CAE6182F230449008B1977 /* LaunchAppExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17CAE6252F230449008B1977 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = LaunchAppExtension; sourceTree = "<group>"; };
 		17E23DE02F443A9300C55733 /* ShareExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (17E23DED2F443A9300C55733 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ShareExtension; sourceTree = "<group>"; };

--- a/LiveContainer/LCBootstrap.m
+++ b/LiveContainer/LCBootstrap.m
@@ -350,7 +350,6 @@ static NSString* invokeAppMain(NSString *selectedApp, NSString *selectedContaine
         tweakFolder = [docPath stringByAppendingPathComponent:@"Tweaks"];
     }
     setenv("LC_GLOBAL_TWEAKS_FOLDER", tweakFolder.UTF8String, 1);
-    setenv("LC_GLOBAL_TWEAKS_IS_GROUP", isSharedBundle ? "1" : "0", 1);
 
     // Update TweakLoader symlink
     NSString *tweakLoaderPath = [tweakFolder stringByAppendingPathComponent:@"TweakLoader.dylib"];
@@ -864,7 +863,6 @@ int LiveContainerMain(int argc, char *argv[]) {
             tweakFolder = [docPath stringByAppendingPathComponent:@"Tweaks"];
         }
         setenv("LC_GLOBAL_TWEAKS_FOLDER", tweakFolder.UTF8String, 1);
-        setenv("LC_GLOBAL_TWEAKS_IS_GROUP", isSharedBundle ? "1" : "0", 1);
 #if TARGET_OS_MACCATALYST || TARGET_OS_SIMULATOR
         extern void DyldHookLoadableIntoProcess(void);
         DyldHookLoadableIntoProcess();

--- a/LiveContainer/LCBootstrap.m
+++ b/LiveContainer/LCBootstrap.m
@@ -350,6 +350,7 @@ static NSString* invokeAppMain(NSString *selectedApp, NSString *selectedContaine
         tweakFolder = [docPath stringByAppendingPathComponent:@"Tweaks"];
     }
     setenv("LC_GLOBAL_TWEAKS_FOLDER", tweakFolder.UTF8String, 1);
+    setenv("LC_GLOBAL_TWEAKS_IS_GROUP", isSharedBundle ? "1" : "0", 1);
 
     // Update TweakLoader symlink
     NSString *tweakLoaderPath = [tweakFolder stringByAppendingPathComponent:@"TweakLoader.dylib"];
@@ -863,6 +864,7 @@ int LiveContainerMain(int argc, char *argv[]) {
             tweakFolder = [docPath stringByAppendingPathComponent:@"Tweaks"];
         }
         setenv("LC_GLOBAL_TWEAKS_FOLDER", tweakFolder.UTF8String, 1);
+        setenv("LC_GLOBAL_TWEAKS_IS_GROUP", isSharedBundle ? "1" : "0", 1);
 #if TARGET_OS_MACCATALYST || TARGET_OS_SIMULATOR
         extern void DyldHookLoadableIntoProcess(void);
         DyldHookLoadableIntoProcess();

--- a/LiveContainer/LCMachOUtils.m
+++ b/LiveContainer/LCMachOUtils.m
@@ -107,6 +107,15 @@ static void insertRPathCommand(const char *path, struct mach_header_64 *header) 
 void LCPatchAddRPath(const char *path, struct mach_header_64 *header) {
     insertRPathCommand("@executable_path/../../Tweaks", header);
     insertRPathCommand("@loader_path", header);
+    // Lets a tweak's "@rpath/Foo.framework/Foo" find Foo.framework even when it was
+    // installed by a *different* deb-imported tweak (each deb-imported tweak's own
+    // resources live nested under its own subfolder, e.g. Tweaks/OtherTweak/Library/
+    // Frameworks/Foo.framework, which the plain "Tweaks" rpath above can't see into).
+    // DebImporter.swift maintains Tweaks/.lc_shared_jbroot as a flat mirror -- symlinks
+    // keyed by each resource's original absolute path -- of every framework/dylib across
+    // every currently-imported tweak, rebuilt each time any tweak is (re)imported. See
+    // DebImporter.swift's rebuildSharedJbroot for the corresponding write side.
+    insertRPathCommand("@executable_path/../../Tweaks/.lc_shared_jbroot", header);
 }
 
 int LCPatchExecSlice(const char *path, struct mach_header_64 *header, bool doInject) {

--- a/LiveContainerSwiftUI/App/LiveContainerSwiftUIApp.swift
+++ b/LiveContainerSwiftUI/App/LiveContainerSwiftUIApp.swift
@@ -79,6 +79,10 @@ struct LiveContainerSwiftUIApp : SwiftUI.App {
             try fm.createDirectory(at: LCPath.tweakPath, withIntermediateDirectories: true)
             let tweakDirs = try fm.contentsOfDirectory(atPath: LCPath.tweakPath.path)
             for tweakDir in tweakDirs {
+                // skip DebImporter's own bookkeeping (.lc_deb_redirects.plist, .lc_shared_jbroot)
+                if tweakDir.hasPrefix(".") {
+                    continue
+                }
                 let tweakDirUrl = LCPath.tweakPath.appendingPathComponent(tweakDir)
                 if !tweakDirUrl.hasDirectoryPath {
                     continue

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -219,6 +219,12 @@ enum DebImporter {
     private static func installPayload(from dataRoot: URL, into destination: URL, tweakName: String) -> [String] {
         let fm = FileManager.default
 
+        // one-time cleanup of on-disk artifacts an earlier build of this feature left
+        // behind, now that redirect data lives in NSUserDefaults and .lc_shared_jbroot is
+        // rebuilt fresh at launch instead of persisted here
+        try? fm.removeItem(at: destination.appendingPathComponent(".lc_deb_redirects.plist"))
+        try? fm.removeItem(at: destination.appendingPathComponent(".lc_shared_jbroot"))
+
         // rootless packages nest everything under var/jb; unwrap that so the mirrored
         // tree starts at Library/... regardless of which convention the .deb used
         var effectiveRoot = dataRoot
@@ -265,14 +271,15 @@ enum DebImporter {
         // (Tweaks/<tweakName>/...), so a ".jbroot" pointing at just *that* tweak's own
         // subfolder would resolve same-package dependencies but never find another
         // package's files. Instead, every tweak's ".jbroot" points at one shared location,
-        // Tweaks/.lc_shared_jbroot -- a flat mirror (see rebuildSharedJbroot) of every
-        // framework/bundle across *every* currently-imported tweak, keyed by original
-        // absolute path -- so cross-package and same-package dependencies resolve the same
-        // way. It's rebuilt on every import, so import order doesn't matter: a tweak
-        // imported before its dependency still finds it once the dependency is imported,
-        // without needing to be re-patched itself. This does NOT help a dependency on a
-        // real system library that was never shipped in any .deb (e.g. libroothide.dylib
-        // itself) -- there's nothing on disk for the mirror to point at.
+        // Tweaks/.lc_shared_jbroot -- a flat mirror, keyed by original absolute path, of
+        // every framework/bundle across *every* currently-imported tweak, so cross-package
+        // and same-package dependencies resolve the same way. DebPathRedirect.m rebuilds it
+        // fresh at every launch (from the same redirect data recordRedirects writes below),
+        // rather than DebImporter maintaining it as persistent, browsable on-disk state, so
+        // import order doesn't matter and nothing here needs to be re-patched when a new
+        // tweak is imported later. This does NOT help a dependency on a real system library
+        // that was never shipped in any .deb (e.g. libroothide.dylib itself) -- there's
+        // nothing for the mirror to point at.
         func createJbrootSymlink(in directory: URL) {
             let components = directory.pathComponents
             guard let tweakNameIndex = components.lastIndex(of: tweakName) else { return }
@@ -332,48 +339,40 @@ enum DebImporter {
         }
 
         recordRedirects(redirects, in: destination)
-        rebuildSharedJbroot(in: destination)
         return [tweakName]
     }
 
-    // Rebuilds Tweaks/.lc_shared_jbroot (or the app-group equivalent) from scratch as a flat
-    // mirror of every framework/bundle any deb-imported tweak under `destination` has ever
-    // registered a redirect for -- the merged .lc_deb_redirects.plist is already exactly
-    // that data, keyed by the resource's original absolute path, so this just re-expresses
-    // each bare-path entry (skipping the "/var/jb"-prefixed duplicate of the same entry, and
-    // the "id:"-prefixed identifier entries, which aren't filesystem paths) as a symlink at
-    // the matching location under .lc_shared_jbroot. Every tweak's own ".jbroot" symlink
-    // (see createJbrootSymlink) and the extra rpath LCPatchAddRPath adds both point at this
-    // fixed location, so refreshing its contents here is all that's needed to pick up a
-    // newly-imported tweak's resources -- no other tweak needs to be re-patched.
-    private static func rebuildSharedJbroot(in destination: URL) {
-        let fm = FileManager.default
-        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
-        guard let merged = NSDictionary(contentsOf: plistUrl) as? [String: String] else { return }
-
-        let sharedRoot = destination.appendingPathComponent(".lc_shared_jbroot")
-        try? fm.removeItem(at: sharedRoot)
-        try? fm.createDirectory(at: sharedRoot, withIntermediateDirectories: true)
-
-        for (from, to) in merged {
-            guard from.hasPrefix("/"), !from.hasPrefix("/var/jb/") else { continue }
-            let relativeComponents = from.split(separator: "/").map(String.init)
-            guard !relativeComponents.isEmpty else { continue }
-            let symlinkUrl = sharedRoot.appendingPathComponent(relativeComponents.joined(separator: "/"))
-            try? fm.createDirectory(at: symlinkUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
-            let upPath = Array(repeating: "..", count: relativeComponents.count).joined(separator: "/")
-            try? fm.createSymbolicLink(atPath: symlinkUrl.path, withDestinationPath: upPath + "/" + to)
-        }
-    }
-
+    // Redirect data is kept in NSUserDefaults (the App Group suite this codebase already
+    // uses for every other piece of persistent LiveContainer config, via
+    // LCUtils.appGroupUserDefault) instead of a dotfile inside the user-browsable Tweaks
+    // folder -- one top-level key per physical tweak-folder root, each holding a dictionary
+    // of scopes ("" for the root's own global entries, or a per-app-selected folder's name)
+    // so DebPathRedirect.m can read back exactly the two locations it already looks at
+    // (globalTweakFolder itself, and globalTweakFolder/<selected folder name>).
+    // Tweaks/.lc_shared_jbroot is no longer built here at all: DebPathRedirect.m rebuilds it
+    // fresh from this same data at every launch instead, so it's never a persistent,
+    // browsable on-disk artifact between launches.
     private static func recordRedirects(_ redirects: [String: String], in destination: URL) {
         guard !redirects.isEmpty else { return }
-        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
-        var merged = (NSDictionary(contentsOf: plistUrl) as? [String: String]) ?? [:]
+        let (key, scope) = debRedirectsConfigScope(for: destination)
+        let defaults = LCUtils.appGroupUserDefault
+        var allScopes = (defaults.dictionary(forKey: key) as? [String: [String: String]]) ?? [:]
+        var scopeEntries = allScopes[scope] ?? [:]
         for (from, to) in redirects {
-            merged[from] = to
+            scopeEntries[from] = to
         }
-        (merged as NSDictionary).write(to: plistUrl, atomically: true)
+        allScopes[scope] = scopeEntries
+        defaults.set(allScopes, forKey: key)
+    }
+
+    // The two physical tweak-folder roots (private vs. shared app-group) each get their own
+    // UserDefaults key; within each, "" is the root's own (global) scope and any other
+    // value is a per-app-selectable subfolder's name.
+    private static func debRedirectsConfigScope(for destination: URL) -> (key: String, scope: String) {
+        let isGroup = destination.path.hasPrefix(LCPath.lcGroupTweakPath.path)
+        let root = isGroup ? LCPath.lcGroupTweakPath : LCPath.tweakPath
+        let scope = destination.path == root.path ? "" : destination.lastPathComponent
+        return (isGroup ? "LCDebRedirectsGroup" : "LCDebRedirectsPrivate", scope)
     }
 
     // Same rpath fixup manual dylib/framework import already applies before signing.

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -12,6 +12,8 @@ import Foundation
 enum DebImportError: LocalizedError {
     case notAnArchive
     case missingDataArchive
+    case corruptDataArchive
+    case nameCollision(String)
 
     var errorDescription: String? {
         switch self {
@@ -19,6 +21,10 @@ enum DebImportError: LocalizedError {
             return "Not a valid .deb (ar) archive"
         case .missingDataArchive:
             return "The .deb package has no data.tar payload"
+        case .corruptDataArchive:
+            return "The .deb package's data.tar payload could not be extracted"
+        case .nameCollision(let name):
+            return "A folder named \"\(name)\" already exists and wasn't created by importing a .deb"
         }
     }
 }
@@ -67,7 +73,9 @@ enum DebImporter {
         // libarchive transparently picks the right decompression filter.
         let dataDir = workDir.appendingPathComponent("data")
         try fm.createDirectory(at: dataDir, withIntermediateDirectories: true)
-        _ = extract(outerDir.appendingPathComponent(dataMember).path, dataDir.path, Progress())
+        guard extract(outerDir.appendingPathComponent(dataMember).path, dataDir.path, Progress()) == 0 else {
+            throw DebImportError.corruptDataArchive
+        }
 
         // Step 3: best-effort control.tar for pre/postinst. Missing or malformed
         // control metadata must not fail the import (required behavior #5).
@@ -95,7 +103,7 @@ enum DebImporter {
         }
         let resolvedTweakName = sanitizeFolderName(tweakName ?? debUrl.deletingPathExtension().lastPathComponent)
 
-        let installedNames = installPayload(from: dataDir, into: destinationFolder, tweakName: resolvedTweakName)
+        let installedNames = try installPayload(from: dataDir, into: destinationFolder, tweakName: resolvedTweakName)
 
         return DebImportResult(installedNames: installedNames, unsupportedScriptLines: unsupportedLines)
     }
@@ -112,7 +120,15 @@ enum DebImporter {
     }
 
     private static func sanitizeFolderName(_ raw: String) -> String {
-        let cleaned = raw.replacingOccurrences(of: "/", with: "-").trimmingCharacters(in: .whitespaces)
+        var cleaned = raw.replacingOccurrences(of: "/", with: "-").trimmingCharacters(in: .whitespaces)
+        // This comes straight from the .deb's own (untrusted) control file, and is about to
+        // be used as a single path component. Strip leading dots so it can never resolve to
+        // "." or ".." (a path-traversal escape out of the tweak folder via
+        // appendingPathComponent) and can never collide with our own dotfile bookkeeping
+        // (.lc_deb_redirects.plist, .lc_shared_jbroot, .lc_deb_tweak).
+        while cleaned.hasPrefix(".") {
+            cleaned.removeFirst()
+        }
         return cleaned.isEmpty ? "Tweak" : cleaned
     }
 
@@ -216,7 +232,7 @@ enum DebImporter {
     // tweak's binary references by *absolute* path (its own bundle, typically) needs a
     // redirect entry since that path no longer exists on disk -- see recordRedirects.
 
-    private static func installPayload(from dataRoot: URL, into destination: URL, tweakName: String) -> [String] {
+    private static func installPayload(from dataRoot: URL, into destination: URL, tweakName: String) throws -> [String] {
         let fm = FileManager.default
 
         // rootless packages nest everything under var/jb; unwrap that so the mirrored
@@ -229,14 +245,35 @@ enum DebImporter {
         }
 
         let tweakDir = destination.appendingPathComponent(tweakName)
-        try? fm.removeItem(at: tweakDir)
-        do {
-            try fm.copyItem(at: effectiveRoot, to: tweakDir)
-        } catch {
-            NSLog("[LC] deb import: failed to install payload for \(tweakName): \(error)")
-            return []
+        var existingIsDir: ObjCBool = false
+        if fm.fileExists(atPath: tweakDir.path, isDirectory: &existingIsDir) {
+            // Only replace something we recognize as our own previous import of this same
+            // tweak (marked with debTweakMarkerName) -- never a folder the user created
+            // themselves or one belonging to a different feature, which a same-named .deb
+            // would otherwise silently wipe out with no confirmation.
+            let looksLikeOurs = existingIsDir.boolValue && fm.fileExists(atPath: tweakDir.appendingPathComponent(debTweakMarkerName).path)
+            guard looksLikeOurs else {
+                throw DebImportError.nameCollision(tweakName)
+            }
+            try fm.removeItem(at: tweakDir)
         }
+        try fm.copyItem(at: effectiveRoot, to: tweakDir)
         fm.createFile(atPath: tweakDir.appendingPathComponent(debTweakMarkerName).path, contents: nil)
+
+        // Resolved once, the same way FileManager's enumerator below canonicalizes the URLs
+        // it yields (e.g. adding a /private prefix) -- everything under tweakDir is then
+        // related back to it by stripping this exact prefix, rather than searching for
+        // tweakName as a path *component*, which breaks if the payload happens to contain a
+        // directory with the same name as the tweak itself (e.g. a tweak named "Frameworks"
+        // shipping its own Library/Frameworks/Foo.framework -- searching by name would match
+        // the inner "Frameworks" instead of the tweak's own root).
+        let canonicalTweakDirPath = tweakDir.resolvingSymlinksInPath().path
+        func relativeComponents(under url: URL) -> [String]? {
+            let path = url.path
+            if path == canonicalTweakDirPath { return [] }
+            guard path.hasPrefix(canonicalTweakDirPath + "/") else { return nil }
+            return path.dropFirst(canonicalTweakDirPath.count + 1).split(separator: "/").map(String.init)
+        }
 
         // absolute path (as the tweak's own compiled-in strings would reference it) -> where
         // we actually put it, so the native path-redirect hook in TweakLoader can resolve it.
@@ -274,11 +311,10 @@ enum DebImporter {
         // real system library that was never shipped in any .deb (e.g. libroothide.dylib
         // itself) -- there's nothing on disk for the mirror to point at.
         func createJbrootSymlink(in directory: URL) {
-            let components = directory.pathComponents
-            guard let tweakNameIndex = components.lastIndex(of: tweakName) else { return }
+            guard let relative = relativeComponents(under: directory) else { return }
             // +1: one more hop than reaching tweakDir, to reach destination (where
             // .lc_shared_jbroot lives, alongside every tweak's own subfolder).
-            let upsToDestination = (components.count - (tweakNameIndex + 1)) + 1
+            let upsToDestination = relative.count + 1
             let upPath = Array(repeating: "..", count: upsToDestination).joined(separator: "/")
             let jbrootUrl = directory.appendingPathComponent(".jbroot")
             try? fm.removeItem(at: jbrootUrl)
@@ -287,18 +323,9 @@ enum DebImporter {
 
         var redirects: [String: String] = [:]
         func recordRedirect(for url: URL) {
-            // Locate our own tweakDir folder name in the path and take everything after it,
-            // rather than dropping tweakDir.pathComponents.count -- FileManager's enumerator
-            // resolves URLs to their canonical form (e.g. adding a /private prefix), which
-            // wouldn't match tweakDir's own component count if tweakDir was built from a
-            // non-canonical URL (this bit us: it silently left a stray "/tweakName" prefix
-            // baked into every redirect key, so nothing ever matched).
-            let components = url.pathComponents
-            guard let tweakNameIndex = components.lastIndex(of: tweakName) else { return }
-            let relativeComponents = Array(components.dropFirst(tweakNameIndex + 1))
-            guard !relativeComponents.isEmpty else { return }
-            let barePath = "/" + relativeComponents.joined(separator: "/")
-            let relativeToDestination = tweakName + "/" + relativeComponents.joined(separator: "/")
+            guard let relative = relativeComponents(under: url), !relative.isEmpty else { return }
+            let barePath = "/" + relative.joined(separator: "/")
+            let relativeToDestination = tweakName + "/" + relative.joined(separator: "/")
             redirects[barePath] = relativeToDestination
             redirects["/var/jb" + barePath] = relativeToDestination
             // also index by the bundle/framework's own CFBundleIdentifier, for tweaks that
@@ -334,6 +361,20 @@ enum DebImporter {
         recordRedirects(redirects, in: destination)
         rebuildSharedJbroot(in: destination)
         return [tweakName]
+    }
+
+    // Called when the user deletes a deb-imported tweak's folder (LCTweaksView.swift), so its
+    // entries in .lc_deb_redirects.plist and its mirrored files under .lc_shared_jbroot don't
+    // linger once the tweak itself is gone -- otherwise DebPathRedirect.m keeps rewriting live
+    // NSBundle/NSFileManager lookups to a path that no longer exists, and other tweaks'
+    // recursive loading keeps trying to dlopen now-dangling symlinks under .lc_shared_jbroot.
+    static func removeTweak(named tweakName: String, from destination: URL) {
+        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
+        guard let merged = NSDictionary(contentsOf: plistUrl) as? [String: String] else { return }
+        let prefix = tweakName + "/"
+        let pruned = merged.filter { !$0.value.hasPrefix(prefix) }
+        (pruned as NSDictionary).write(to: plistUrl, atomically: true)
+        rebuildSharedJbroot(in: destination)
     }
 
     // Rebuilds Tweaks/.lc_shared_jbroot (or the app-group equivalent) from scratch as a flat

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -30,12 +30,11 @@ struct DebImportResult {
 }
 
 enum DebImporter {
-    // Rootless tweaks put their payload under these paths (with or without a
-    // leading /var/jb prefix, depending on how the .deb was built); we match on
-    // the trailing path components only so both conventions resolve the same way.
+    // Rootless tweaks put their dylib under this path (with or without a leading /var/jb
+    // prefix, depending on how the .deb was built); we match on the trailing path components
+    // only so both conventions resolve the same way. Resource bundles/frameworks aren't
+    // pinned to one directory convention -- see installPayload below.
     private static let dynamicLibrariesSuffix = ["Library", "MobileSubstrate", "DynamicLibraries"]
-    private static let frameworksSuffix = ["Library", "Frameworks"]
-    private static let preferenceBundlesSuffix = ["Library", "PreferenceBundles"]
 
     private static let supportedScriptCommands: Set<String> = ["mv", "cp", "mkdir", "ln"]
 
@@ -192,10 +191,12 @@ enum DebImporter {
     private static func installPayload(from dataRoot: URL, into destination: URL) -> [String] {
         let fm = FileManager.default
         var installed: [String] = []
+        // absolute path (as the tweak's own compiled-in strings would reference it) -> where
+        // we actually put it, so the native path-redirect hook in TweakLoader can resolve it
+        var redirects: [String: String] = [:]
 
         var dynamicLibDirs: [URL] = []
-        var frameworksDirs: [URL] = []
-        var preferenceBundleDirs: [URL] = []
+        var resourceDirs: [URL] = []
 
         if let enumerator = fm.enumerator(at: dataRoot, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) {
             for case let url as URL in enumerator {
@@ -203,15 +204,36 @@ enum DebImporter {
                 guard fm.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else { continue }
                 if pathEndsWith(url, dynamicLibrariesSuffix) {
                     dynamicLibDirs.append(url)
-                } else if pathEndsWith(url, frameworksSuffix) {
-                    frameworksDirs.append(url)
-                } else if pathEndsWith(url, preferenceBundlesSuffix) {
-                    preferenceBundleDirs.append(url)
+                    continue
+                }
+                // Tweaks stash their resource bundles/frameworks all over the place --
+                // Library/PreferenceBundles, Library/Frameworks, Library/Application Support,
+                // vendor-specific folders, etc. Rather than enumerate every convention, grab
+                // any *.framework/*.bundle directory wherever it lives, and don't descend into
+                // it any further (its contents are copied as one unit).
+                let ext = url.pathExtension.lowercased()
+                if ext == "framework" || ext == "bundle" {
+                    resourceDirs.append(url)
+                    enumerator.skipDescendants()
                 }
             }
         }
 
-        func install(_ itemUrl: URL, patchMachO: Bool) {
+        // maps the absolute path form the tweak's own binary might reference (with or without
+        // the rootless /var/jb prefix) to where we're about to install this item.
+        func recordRedirect(for itemUrl: URL, installedAt dest: URL) {
+            var relativeComponents = Array(itemUrl.pathComponents.dropFirst(dataRoot.pathComponents.count))
+            if relativeComponents.count >= 2, relativeComponents[0] == "var", relativeComponents[1] == "jb" {
+                relativeComponents.removeFirst(2)
+            }
+            guard !relativeComponents.isEmpty else { return }
+            let barePath = "/" + relativeComponents.joined(separator: "/")
+            let rootlessPath = "/var/jb" + barePath
+            redirects[barePath] = dest.path
+            redirects[rootlessPath] = dest.path
+        }
+
+        func install(_ itemUrl: URL, patchMachO: Bool, recordAsRedirect: Bool) {
             let dest = destination.appendingPathComponent(itemUrl.lastPathComponent)
             if fm.fileExists(atPath: dest.path) {
                 try? fm.removeItem(at: dest)
@@ -225,6 +247,9 @@ enum DebImporter {
             if patchMachO {
                 patchRPath(at: dest)
             }
+            if recordAsRedirect {
+                recordRedirect(for: itemUrl, installedAt: dest)
+            }
             installed.append(itemUrl.lastPathComponent)
         }
 
@@ -233,23 +258,26 @@ enum DebImporter {
             for child in children {
                 let ext = child.pathExtension.lowercased()
                 guard ext == "dylib" || ext == "plist" else { continue }
-                install(child, patchMachO: ext == "dylib")
+                install(child, patchMachO: ext == "dylib", recordAsRedirect: false)
             }
         }
-        for dir in frameworksDirs {
-            let children = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
-            for child in children where child.pathExtension.lowercased() == "framework" {
-                install(child, patchMachO: true)
-            }
-        }
-        for dir in preferenceBundleDirs {
-            let children = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
-            for child in children where child.pathExtension.lowercased() == "bundle" {
-                install(child, patchMachO: false)
-            }
+        for resourceDir in resourceDirs {
+            let ext = resourceDir.pathExtension.lowercased()
+            install(resourceDir, patchMachO: ext == "framework", recordAsRedirect: true)
         }
 
+        recordRedirects(redirects, in: destination)
         return installed
+    }
+
+    private static func recordRedirects(_ redirects: [String: String], in destination: URL) {
+        guard !redirects.isEmpty else { return }
+        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
+        var merged = (NSDictionary(contentsOf: plistUrl) as? [String: String]) ?? [:]
+        for (from, to) in redirects {
+            merged[from] = to
+        }
+        (merged as NSDictionary).write(to: plistUrl, atomically: true)
     }
 
     // Same rpath fixup manual dylib/framework import already applies before signing.

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -237,6 +237,12 @@ enum DebImporter {
             let barePath = "/" + relativeComponents.joined(separator: "/")
             redirects[barePath] = url.path
             redirects["/var/jb" + barePath] = url.path
+            // also index by the bundle/framework's own CFBundleIdentifier, for tweaks that
+            // look their bundle up that way instead of by a hardcoded path
+            if let info = NSDictionary(contentsOf: url.appendingPathComponent("Info.plist")),
+               let identifier = info["CFBundleIdentifier"] as? String {
+                redirects["id:" + identifier] = url.path
+            }
         }
 
         if let enumerator = fm.enumerator(at: tweakDir, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) {

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -30,12 +30,6 @@ struct DebImportResult {
 }
 
 enum DebImporter {
-    // Rootless tweaks put their dylib under this path (with or without a leading /var/jb
-    // prefix, depending on how the .deb was built); we match on the trailing path components
-    // only so both conventions resolve the same way. Resource bundles/frameworks aren't
-    // pinned to one directory convention -- see installPayload below.
-    private static let dynamicLibrariesSuffix = ["Library", "MobileSubstrate", "DynamicLibraries"]
-
     private static let supportedScriptCommands: Set<String> = ["mv", "cp", "mkdir", "ln"]
 
     static func importDeb(at debUrl: URL, into destinationFolder: URL) throws -> DebImportResult {
@@ -82,11 +76,35 @@ enum DebImporter {
             }
         }
 
-        // Step 4: find the payload under the well-known rootless tweak dirs and
-        // hand it to the same folder the manual dylib/framework importer uses.
-        let installedNames = installPayload(from: dataDir, into: destinationFolder)
+        // Step 4: name the tweak (control's Name/Package field, else the .deb's own
+        // filename) and mirror its whole payload tree into a subfolder of that name so
+        // the original layout -- and thus every resource path inside it -- is preserved.
+        let controlFileUrl = workDir.appendingPathComponent("control").appendingPathComponent("control")
+        var tweakName: String?
+        if let controlText = try? String(contentsOf: controlFileUrl, encoding: .utf8) {
+            tweakName = parseControlField("Name", from: controlText) ?? parseControlField("Package", from: controlText)
+        }
+        let resolvedTweakName = sanitizeFolderName(tweakName ?? debUrl.deletingPathExtension().lastPathComponent)
+
+        let installedNames = installPayload(from: dataDir, into: destinationFolder, tweakName: resolvedTweakName)
 
         return DebImportResult(installedNames: installedNames, unsupportedScriptLines: unsupportedLines)
+    }
+
+    private static func parseControlField(_ key: String, from control: String) -> String? {
+        for line in control.split(separator: "\n") {
+            guard let colonIndex = line.firstIndex(of: ":") else { continue }
+            let fieldName = line[line.startIndex..<colonIndex].trimmingCharacters(in: .whitespaces)
+            guard fieldName == key else { continue }
+            let value = line[line.index(after: colonIndex)...].trimmingCharacters(in: .whitespaces)
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
+
+    private static func sanitizeFolderName(_ raw: String) -> String {
+        let cleaned = raw.replacingOccurrences(of: "/", with: "-").trimmingCharacters(in: .whitespaces)
+        return cleaned.isEmpty ? "Tweak" : cleaned
     }
 
     // MARK: - Safe control-script subset
@@ -181,93 +199,68 @@ enum DebImporter {
     }
 
     // MARK: - Payload layout remap
+    //
+    // The whole data.tar payload is mirrored as-is under <destination>/<tweakName>/, so
+    // the tweak's own directory structure (and thus every relative reference inside it)
+    // stays intact -- TweakLoader.m already recurses arbitrarily deep looking for
+    // .dylib/.framework, so nesting doesn't stop it from finding them. Anything the
+    // tweak's binary references by *absolute* path (its own bundle, typically) needs a
+    // redirect entry since that path no longer exists on disk -- see recordRedirects.
 
-    private static func pathEndsWith(_ url: URL, _ suffix: [String]) -> Bool {
-        let comps = url.pathComponents
-        guard comps.count >= suffix.count else { return false }
-        return zip(comps.suffix(suffix.count), suffix).allSatisfy { $0.caseInsensitiveCompare($1) == .orderedSame }
-    }
-
-    private static func installPayload(from dataRoot: URL, into destination: URL) -> [String] {
+    private static func installPayload(from dataRoot: URL, into destination: URL, tweakName: String) -> [String] {
         let fm = FileManager.default
-        var installed: [String] = []
+
+        // rootless packages nest everything under var/jb; unwrap that so the mirrored
+        // tree starts at Library/... regardless of which convention the .deb used
+        var effectiveRoot = dataRoot
+        let varJbRoot = dataRoot.appendingPathComponent("var/jb")
+        var isVarJbDir: ObjCBool = false
+        if fm.fileExists(atPath: varJbRoot.path, isDirectory: &isVarJbDir), isVarJbDir.boolValue {
+            effectiveRoot = varJbRoot
+        }
+
+        let tweakDir = destination.appendingPathComponent(tweakName)
+        try? fm.removeItem(at: tweakDir)
+        do {
+            try fm.copyItem(at: effectiveRoot, to: tweakDir)
+        } catch {
+            NSLog("[LC] deb import: failed to install payload for \(tweakName): \(error)")
+            return []
+        }
+
         // absolute path (as the tweak's own compiled-in strings would reference it) -> where
         // we actually put it, so the native path-redirect hook in TweakLoader can resolve it
         var redirects: [String: String] = [:]
-
-        var dynamicLibDirs: [URL] = []
-        var resourceDirs: [URL] = []
-
-        if let enumerator = fm.enumerator(at: dataRoot, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) {
-            for case let url as URL in enumerator {
-                var isDir: ObjCBool = false
-                guard fm.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else { continue }
-                if pathEndsWith(url, dynamicLibrariesSuffix) {
-                    dynamicLibDirs.append(url)
-                    continue
-                }
-                // Tweaks stash their resource bundles/frameworks all over the place --
-                // Library/PreferenceBundles, Library/Frameworks, Library/Application Support,
-                // vendor-specific folders, etc. Rather than enumerate every convention, grab
-                // any *.framework/*.bundle directory wherever it lives, and don't descend into
-                // it any further (its contents are copied as one unit).
-                let ext = url.pathExtension.lowercased()
-                if ext == "framework" || ext == "bundle" {
-                    resourceDirs.append(url)
-                    enumerator.skipDescendants()
-                }
-            }
-        }
-
-        // maps the absolute path form the tweak's own binary might reference (with or without
-        // the rootless /var/jb prefix) to where we're about to install this item.
-        func recordRedirect(for itemUrl: URL, installedAt dest: URL) {
-            var relativeComponents = Array(itemUrl.pathComponents.dropFirst(dataRoot.pathComponents.count))
-            if relativeComponents.count >= 2, relativeComponents[0] == "var", relativeComponents[1] == "jb" {
-                relativeComponents.removeFirst(2)
-            }
+        func recordRedirect(for url: URL) {
+            let relativeComponents = Array(url.pathComponents.dropFirst(tweakDir.pathComponents.count))
             guard !relativeComponents.isEmpty else { return }
             let barePath = "/" + relativeComponents.joined(separator: "/")
-            let rootlessPath = "/var/jb" + barePath
-            redirects[barePath] = dest.path
-            redirects[rootlessPath] = dest.path
+            redirects[barePath] = url.path
+            redirects["/var/jb" + barePath] = url.path
         }
 
-        func install(_ itemUrl: URL, patchMachO: Bool, recordAsRedirect: Bool) {
-            let dest = destination.appendingPathComponent(itemUrl.lastPathComponent)
-            if fm.fileExists(atPath: dest.path) {
-                try? fm.removeItem(at: dest)
+        if let enumerator = fm.enumerator(at: tweakDir, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) {
+            for case let url as URL in enumerator {
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: url.path, isDirectory: &isDir) else { continue }
+                let ext = url.pathExtension.lowercased()
+                if isDir.boolValue, ext == "framework" {
+                    patchRPath(at: url)
+                    recordRedirect(for: url)
+                    enumerator.skipDescendants()
+                } else if isDir.boolValue, ext == "bundle" {
+                    // resource bundles aren't Mach-O, but they're still referenced by
+                    // absolute path just like frameworks are
+                    recordRedirect(for: url)
+                    enumerator.skipDescendants()
+                } else if !isDir.boolValue, ext == "dylib" {
+                    patchRPath(at: url)
+                }
             }
-            do {
-                try fm.copyItem(at: itemUrl, to: dest)
-            } catch {
-                NSLog("[LC] deb import: failed to install \(itemUrl.lastPathComponent): \(error)")
-                return
-            }
-            if patchMachO {
-                patchRPath(at: dest)
-            }
-            if recordAsRedirect {
-                recordRedirect(for: itemUrl, installedAt: dest)
-            }
-            installed.append(itemUrl.lastPathComponent)
-        }
-
-        for dir in dynamicLibDirs {
-            let children = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
-            for child in children {
-                let ext = child.pathExtension.lowercased()
-                guard ext == "dylib" || ext == "plist" else { continue }
-                install(child, patchMachO: ext == "dylib", recordAsRedirect: false)
-            }
-        }
-        for resourceDir in resourceDirs {
-            let ext = resourceDir.pathExtension.lowercased()
-            install(resourceDir, patchMachO: ext == "framework", recordAsRedirect: true)
         }
 
         recordRedirects(redirects, in: destination)
-        return installed
+        return [tweakName]
     }
 
     private static func recordRedirects(_ redirects: [String: String], in destination: URL) {

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -219,12 +219,6 @@ enum DebImporter {
     private static func installPayload(from dataRoot: URL, into destination: URL, tweakName: String) -> [String] {
         let fm = FileManager.default
 
-        // one-time cleanup of on-disk artifacts an earlier build of this feature left
-        // behind, now that redirect data lives in NSUserDefaults and .lc_shared_jbroot is
-        // rebuilt fresh at launch instead of persisted here
-        try? fm.removeItem(at: destination.appendingPathComponent(".lc_deb_redirects.plist"))
-        try? fm.removeItem(at: destination.appendingPathComponent(".lc_shared_jbroot"))
-
         // rootless packages nest everything under var/jb; unwrap that so the mirrored
         // tree starts at Library/... regardless of which convention the .deb used
         var effectiveRoot = dataRoot
@@ -271,15 +265,14 @@ enum DebImporter {
         // (Tweaks/<tweakName>/...), so a ".jbroot" pointing at just *that* tweak's own
         // subfolder would resolve same-package dependencies but never find another
         // package's files. Instead, every tweak's ".jbroot" points at one shared location,
-        // Tweaks/.lc_shared_jbroot -- a flat mirror, keyed by original absolute path, of
-        // every framework/bundle across *every* currently-imported tweak, so cross-package
-        // and same-package dependencies resolve the same way. DebPathRedirect.m rebuilds it
-        // fresh at every launch (from the same redirect data recordRedirects writes below),
-        // rather than DebImporter maintaining it as persistent, browsable on-disk state, so
-        // import order doesn't matter and nothing here needs to be re-patched when a new
-        // tweak is imported later. This does NOT help a dependency on a real system library
-        // that was never shipped in any .deb (e.g. libroothide.dylib itself) -- there's
-        // nothing for the mirror to point at.
+        // Tweaks/.lc_shared_jbroot -- a flat mirror (see rebuildSharedJbroot) of every
+        // framework/bundle across *every* currently-imported tweak, keyed by original
+        // absolute path -- so cross-package and same-package dependencies resolve the same
+        // way. It's rebuilt on every import, so import order doesn't matter: a tweak
+        // imported before its dependency still finds it once the dependency is imported,
+        // without needing to be re-patched itself. This does NOT help a dependency on a
+        // real system library that was never shipped in any .deb (e.g. libroothide.dylib
+        // itself) -- there's nothing on disk for the mirror to point at.
         func createJbrootSymlink(in directory: URL) {
             let components = directory.pathComponents
             guard let tweakNameIndex = components.lastIndex(of: tweakName) else { return }
@@ -339,40 +332,48 @@ enum DebImporter {
         }
 
         recordRedirects(redirects, in: destination)
+        rebuildSharedJbroot(in: destination)
         return [tweakName]
     }
 
-    // Redirect data is kept in NSUserDefaults (the App Group suite this codebase already
-    // uses for every other piece of persistent LiveContainer config, via
-    // LCUtils.appGroupUserDefault) instead of a dotfile inside the user-browsable Tweaks
-    // folder -- one top-level key per physical tweak-folder root, each holding a dictionary
-    // of scopes ("" for the root's own global entries, or a per-app-selected folder's name)
-    // so DebPathRedirect.m can read back exactly the two locations it already looks at
-    // (globalTweakFolder itself, and globalTweakFolder/<selected folder name>).
-    // Tweaks/.lc_shared_jbroot is no longer built here at all: DebPathRedirect.m rebuilds it
-    // fresh from this same data at every launch instead, so it's never a persistent,
-    // browsable on-disk artifact between launches.
-    private static func recordRedirects(_ redirects: [String: String], in destination: URL) {
-        guard !redirects.isEmpty else { return }
-        let (key, scope) = debRedirectsConfigScope(for: destination)
-        let defaults = LCUtils.appGroupUserDefault
-        var allScopes = (defaults.dictionary(forKey: key) as? [String: [String: String]]) ?? [:]
-        var scopeEntries = allScopes[scope] ?? [:]
-        for (from, to) in redirects {
-            scopeEntries[from] = to
+    // Rebuilds Tweaks/.lc_shared_jbroot (or the app-group equivalent) from scratch as a flat
+    // mirror of every framework/bundle any deb-imported tweak under `destination` has ever
+    // registered a redirect for -- the merged .lc_deb_redirects.plist is already exactly
+    // that data, keyed by the resource's original absolute path, so this just re-expresses
+    // each bare-path entry (skipping the "/var/jb"-prefixed duplicate of the same entry, and
+    // the "id:"-prefixed identifier entries, which aren't filesystem paths) as a symlink at
+    // the matching location under .lc_shared_jbroot. Every tweak's own ".jbroot" symlink
+    // (see createJbrootSymlink) and the extra rpath LCPatchAddRPath adds both point at this
+    // fixed location, so refreshing its contents here is all that's needed to pick up a
+    // newly-imported tweak's resources -- no other tweak needs to be re-patched.
+    private static func rebuildSharedJbroot(in destination: URL) {
+        let fm = FileManager.default
+        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
+        guard let merged = NSDictionary(contentsOf: plistUrl) as? [String: String] else { return }
+
+        let sharedRoot = destination.appendingPathComponent(".lc_shared_jbroot")
+        try? fm.removeItem(at: sharedRoot)
+        try? fm.createDirectory(at: sharedRoot, withIntermediateDirectories: true)
+
+        for (from, to) in merged {
+            guard from.hasPrefix("/"), !from.hasPrefix("/var/jb/") else { continue }
+            let relativeComponents = from.split(separator: "/").map(String.init)
+            guard !relativeComponents.isEmpty else { continue }
+            let symlinkUrl = sharedRoot.appendingPathComponent(relativeComponents.joined(separator: "/"))
+            try? fm.createDirectory(at: symlinkUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let upPath = Array(repeating: "..", count: relativeComponents.count).joined(separator: "/")
+            try? fm.createSymbolicLink(atPath: symlinkUrl.path, withDestinationPath: upPath + "/" + to)
         }
-        allScopes[scope] = scopeEntries
-        defaults.set(allScopes, forKey: key)
     }
 
-    // The two physical tweak-folder roots (private vs. shared app-group) each get their own
-    // UserDefaults key; within each, "" is the root's own (global) scope and any other
-    // value is a per-app-selectable subfolder's name.
-    private static func debRedirectsConfigScope(for destination: URL) -> (key: String, scope: String) {
-        let isGroup = destination.path.hasPrefix(LCPath.lcGroupTweakPath.path)
-        let root = isGroup ? LCPath.lcGroupTweakPath : LCPath.tweakPath
-        let scope = destination.path == root.path ? "" : destination.lastPathComponent
-        return (isGroup ? "LCDebRedirectsGroup" : "LCDebRedirectsPrivate", scope)
+    private static func recordRedirects(_ redirects: [String: String], in destination: URL) {
+        guard !redirects.isEmpty else { return }
+        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
+        var merged = (NSDictionary(contentsOf: plistUrl) as? [String: String]) ?? [:]
+        for (from, to) in redirects {
+            merged[from] = to
+        }
+        (merged as NSDictionary).write(to: plistUrl, atomically: true)
     }
 
     // Same rpath fixup manual dylib/framework import already applies before signing.

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -30,6 +30,15 @@ struct DebImportResult {
 }
 
 enum DebImporter {
+    // Marks a deb-imported tweak's own folder so it can be told apart from a folder the
+    // user created themselves to group/select tweaks per-app: LCTweaksView.swift shows a
+    // different icon for it, and TweakLoader.m's global-tweaks loop uses its presence to
+    // decide a top-level folder should load for every app (like a loose .dylib does)
+    // rather than only for an app that has explicitly selected it. TweakLoader.m can't
+    // reference this constant directly (it's a separate dylib target), so its copy of the
+    // literal name must be kept in sync with this one.
+    static let debTweakMarkerName = ".lc_deb_tweak"
+
     private static let supportedScriptCommands: Set<String> = ["mv", "cp", "mkdir", "ln"]
 
     static func importDeb(at debUrl: URL, into destinationFolder: URL) throws -> DebImportResult {
@@ -227,6 +236,7 @@ enum DebImporter {
             NSLog("[LC] deb import: failed to install payload for \(tweakName): \(error)")
             return []
         }
+        fm.createFile(atPath: tweakDir.appendingPathComponent(debTweakMarkerName).path, contents: nil)
 
         // absolute path (as the tweak's own compiled-in strings would reference it) -> where
         // we actually put it, so the native path-redirect hook in TweakLoader can resolve it.
@@ -242,6 +252,39 @@ enum DebImporter {
         // tweak is re-imported. Storing a root-relative path and letting DebPathRedirect.m
         // re-resolve it against whichever root is actually current at each launch keeps the
         // mapping valid across both.
+        // Some tweaks reference dependencies -- their own co-bundled ones (e.g. a Swift
+        // runtime framework shipped in the same .deb) as well as ones from a *different*
+        // tweak entirely (e.g. one package's dylib linking a shared framework a separate
+        // "support library" package installs) -- via "@loader_path/.jbroot/..." instead of
+        // @rpath. ".jbroot" is a convention from real rootless jailbreaks: a symlink next to
+        // every installed dylib pointing back at the (possibly randomized) real jailbreak
+        // root, so tweaks find absolute-looking paths without hardcoding where the root
+        // actually is. dyld resolves that symlink itself at dlopen time.
+        //
+        // Every deb-imported tweak's own payload lives nested under its own subfolder
+        // (Tweaks/<tweakName>/...), so a ".jbroot" pointing at just *that* tweak's own
+        // subfolder would resolve same-package dependencies but never find another
+        // package's files. Instead, every tweak's ".jbroot" points at one shared location,
+        // Tweaks/.lc_shared_jbroot -- a flat mirror (see rebuildSharedJbroot) of every
+        // framework/bundle across *every* currently-imported tweak, keyed by original
+        // absolute path -- so cross-package and same-package dependencies resolve the same
+        // way. It's rebuilt on every import, so import order doesn't matter: a tweak
+        // imported before its dependency still finds it once the dependency is imported,
+        // without needing to be re-patched itself. This does NOT help a dependency on a
+        // real system library that was never shipped in any .deb (e.g. libroothide.dylib
+        // itself) -- there's nothing on disk for the mirror to point at.
+        func createJbrootSymlink(in directory: URL) {
+            let components = directory.pathComponents
+            guard let tweakNameIndex = components.lastIndex(of: tweakName) else { return }
+            // +1: one more hop than reaching tweakDir, to reach destination (where
+            // .lc_shared_jbroot lives, alongside every tweak's own subfolder).
+            let upsToDestination = (components.count - (tweakNameIndex + 1)) + 1
+            let upPath = Array(repeating: "..", count: upsToDestination).joined(separator: "/")
+            let jbrootUrl = directory.appendingPathComponent(".jbroot")
+            try? fm.removeItem(at: jbrootUrl)
+            try? fm.createSymbolicLink(atPath: jbrootUrl.path, withDestinationPath: upPath + "/.lc_shared_jbroot")
+        }
+
         var redirects: [String: String] = [:]
         func recordRedirect(for url: URL) {
             // Locate our own tweakDir folder name in the path and take everything after it,
@@ -274,6 +317,7 @@ enum DebImporter {
                 if isDir.boolValue, ext == "framework" {
                     patchRPath(at: url)
                     recordRedirect(for: url)
+                    createJbrootSymlink(in: url)
                     enumerator.skipDescendants()
                 } else if isDir.boolValue, ext == "bundle" {
                     // resource bundles aren't Mach-O, but they're still referenced by
@@ -282,12 +326,44 @@ enum DebImporter {
                     enumerator.skipDescendants()
                 } else if !isDir.boolValue, ext == "dylib" {
                     patchRPath(at: url)
+                    createJbrootSymlink(in: url.deletingLastPathComponent())
                 }
             }
         }
 
         recordRedirects(redirects, in: destination)
+        rebuildSharedJbroot(in: destination)
         return [tweakName]
+    }
+
+    // Rebuilds Tweaks/.lc_shared_jbroot (or the app-group equivalent) from scratch as a flat
+    // mirror of every framework/bundle any deb-imported tweak under `destination` has ever
+    // registered a redirect for -- the merged .lc_deb_redirects.plist is already exactly
+    // that data, keyed by the resource's original absolute path, so this just re-expresses
+    // each bare-path entry (skipping the "/var/jb"-prefixed duplicate of the same entry, and
+    // the "id:"-prefixed identifier entries, which aren't filesystem paths) as a symlink at
+    // the matching location under .lc_shared_jbroot. Every tweak's own ".jbroot" symlink
+    // (see createJbrootSymlink) and the extra rpath LCPatchAddRPath adds both point at this
+    // fixed location, so refreshing its contents here is all that's needed to pick up a
+    // newly-imported tweak's resources -- no other tweak needs to be re-patched.
+    private static func rebuildSharedJbroot(in destination: URL) {
+        let fm = FileManager.default
+        let plistUrl = destination.appendingPathComponent(".lc_deb_redirects.plist")
+        guard let merged = NSDictionary(contentsOf: plistUrl) as? [String: String] else { return }
+
+        let sharedRoot = destination.appendingPathComponent(".lc_shared_jbroot")
+        try? fm.removeItem(at: sharedRoot)
+        try? fm.createDirectory(at: sharedRoot, withIntermediateDirectories: true)
+
+        for (from, to) in merged {
+            guard from.hasPrefix("/"), !from.hasPrefix("/var/jb/") else { continue }
+            let relativeComponents = from.split(separator: "/").map(String.init)
+            guard !relativeComponents.isEmpty else { continue }
+            let symlinkUrl = sharedRoot.appendingPathComponent(relativeComponents.joined(separator: "/"))
+            try? fm.createDirectory(at: symlinkUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
+            let upPath = Array(repeating: "..", count: relativeComponents.count).joined(separator: "/")
+            try? fm.createSymbolicLink(atPath: symlinkUrl.path, withDestinationPath: upPath + "/" + to)
+        }
     }
 
     private static func recordRedirects(_ redirects: [String: String], in destination: URL) {

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -232,7 +232,15 @@ enum DebImporter {
         // we actually put it, so the native path-redirect hook in TweakLoader can resolve it
         var redirects: [String: String] = [:]
         func recordRedirect(for url: URL) {
-            let relativeComponents = Array(url.pathComponents.dropFirst(tweakDir.pathComponents.count))
+            // Locate our own tweakDir folder name in the path and take everything after it,
+            // rather than dropping tweakDir.pathComponents.count -- FileManager's enumerator
+            // resolves URLs to their canonical form (e.g. adding a /private prefix), which
+            // wouldn't match tweakDir's own component count if tweakDir was built from a
+            // non-canonical URL (this bit us: it silently left a stray "/tweakName" prefix
+            // baked into every redirect key, so nothing ever matched).
+            let components = url.pathComponents
+            guard let tweakNameIndex = components.lastIndex(of: tweakName) else { return }
+            let relativeComponents = Array(components.dropFirst(tweakNameIndex + 1))
             guard !relativeComponents.isEmpty else { return }
             let barePath = "/" + relativeComponents.joined(separator: "/")
             redirects[barePath] = url.path

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -229,7 +229,19 @@ enum DebImporter {
         }
 
         // absolute path (as the tweak's own compiled-in strings would reference it) -> where
-        // we actually put it, so the native path-redirect hook in TweakLoader can resolve it
+        // we actually put it, so the native path-redirect hook in TweakLoader can resolve it.
+        //
+        // The "where we put it" side is stored *relative to destination* (the tweak-folder
+        // root), not as an absolute path: destination lives inside LiveContainer's own app
+        // container (LCPath.tweakPath) or the shared app-group container
+        // (LCPath.lcGroupTweakPath), and both of those roots can change out from under an
+        // already-imported tweak -- LiveContainer being reinstalled/updated gets a brand new
+        // sandbox container UUID, and "convert app to shared" physically moves the whole
+        // tweak folder from one root to the other. An absolute path baked in at import time
+        // goes stale the moment either happens, silently breaking every redirect until the
+        // tweak is re-imported. Storing a root-relative path and letting DebPathRedirect.m
+        // re-resolve it against whichever root is actually current at each launch keeps the
+        // mapping valid across both.
         var redirects: [String: String] = [:]
         func recordRedirect(for url: URL) {
             // Locate our own tweakDir folder name in the path and take everything after it,
@@ -243,13 +255,14 @@ enum DebImporter {
             let relativeComponents = Array(components.dropFirst(tweakNameIndex + 1))
             guard !relativeComponents.isEmpty else { return }
             let barePath = "/" + relativeComponents.joined(separator: "/")
-            redirects[barePath] = url.path
-            redirects["/var/jb" + barePath] = url.path
+            let relativeToDestination = tweakName + "/" + relativeComponents.joined(separator: "/")
+            redirects[barePath] = relativeToDestination
+            redirects["/var/jb" + barePath] = relativeToDestination
             // also index by the bundle/framework's own CFBundleIdentifier, for tweaks that
             // look their bundle up that way instead of by a hardcoded path
             if let info = NSDictionary(contentsOf: url.appendingPathComponent("Info.plist")),
                let identifier = info["CFBundleIdentifier"] as? String {
-                redirects["id:" + identifier] = url.path
+                redirects["id:" + identifier] = relativeToDestination
             }
         }
 

--- a/LiveContainerSwiftUI/Utilities/DebImporter.swift
+++ b/LiveContainerSwiftUI/Utilities/DebImporter.swift
@@ -1,0 +1,268 @@
+//
+//  DebImporter.swift
+//  LiveContainerSwiftUI
+//
+//  Imports rootless-jailbreak .deb tweak packages into a LiveContainer tweak folder,
+//  reusing the existing ar/tar extraction (unarchive.m -> libarchive) and MachO
+//  rpath-patching code already used for manually-imported dylib/framework tweaks.
+//
+
+import Foundation
+
+enum DebImportError: LocalizedError {
+    case notAnArchive
+    case missingDataArchive
+
+    var errorDescription: String? {
+        switch self {
+        case .notAnArchive:
+            return "Not a valid .deb (ar) archive"
+        case .missingDataArchive:
+            return "The .deb package has no data.tar payload"
+        }
+    }
+}
+
+struct DebImportResult {
+    let installedNames: [String]
+    // raw postinst/preinst lines outside the mv/cp/mkdir/ln-s subset that were skipped
+    let unsupportedScriptLines: [String]
+}
+
+enum DebImporter {
+    // Rootless tweaks put their payload under these paths (with or without a
+    // leading /var/jb prefix, depending on how the .deb was built); we match on
+    // the trailing path components only so both conventions resolve the same way.
+    private static let dynamicLibrariesSuffix = ["Library", "MobileSubstrate", "DynamicLibraries"]
+    private static let frameworksSuffix = ["Library", "Frameworks"]
+    private static let preferenceBundlesSuffix = ["Library", "PreferenceBundles"]
+
+    private static let supportedScriptCommands: Set<String> = ["mv", "cp", "mkdir", "ln"]
+
+    static func importDeb(at debUrl: URL, into destinationFolder: URL) throws -> DebImportResult {
+        let fm = FileManager.default
+        let workDir = fm.temporaryDirectory.appendingPathComponent("deb-\(UUID().uuidString)")
+        try fm.createDirectory(at: workDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: workDir) }
+
+        // Step 1: extract the outer `ar` container. This yields flat files:
+        // debian-binary, control.tar.*, data.tar.* -- reusing the same extract()
+        // used for IPA unzipping, since libarchive's "all formats" reader already
+        // understands `ar`.
+        let outerDir = workDir.appendingPathComponent("outer")
+        try fm.createDirectory(at: outerDir, withIntermediateDirectories: true)
+        guard extract(debUrl.path, outerDir.path, Progress()) == 0 else {
+            throw DebImportError.notAnArchive
+        }
+
+        let outerEntries = (try? fm.contentsOfDirectory(atPath: outerDir.path)) ?? []
+        guard let dataMember = outerEntries.first(where: { $0.hasPrefix("data.tar") }) else {
+            throw DebImportError.missingDataArchive
+        }
+        let controlMember = outerEntries.first(where: { $0.hasPrefix("control.tar") })
+
+        // Step 2: extract data.tar(.gz/.xz/.zst) -- again the same extract(), since
+        // libarchive transparently picks the right decompression filter.
+        let dataDir = workDir.appendingPathComponent("data")
+        try fm.createDirectory(at: dataDir, withIntermediateDirectories: true)
+        _ = extract(outerDir.appendingPathComponent(dataMember).path, dataDir.path, Progress())
+
+        // Step 3: best-effort control.tar for pre/postinst. Missing or malformed
+        // control metadata must not fail the import (required behavior #5).
+        var unsupportedLines: [String] = []
+        if let controlMember {
+            let controlDir = workDir.appendingPathComponent("control")
+            try? fm.createDirectory(at: controlDir, withIntermediateDirectories: true)
+            if extract(outerDir.appendingPathComponent(controlMember).path, controlDir.path, Progress()) == 0 {
+                for scriptName in ["preinst", "postinst"] {
+                    let scriptUrl = controlDir.appendingPathComponent(scriptName)
+                    if let contents = try? String(contentsOf: scriptUrl, encoding: .utf8) {
+                        unsupportedLines.append(contentsOf: applyControlScript(contents, dataRoot: dataDir))
+                    }
+                }
+            }
+        }
+
+        // Step 4: find the payload under the well-known rootless tweak dirs and
+        // hand it to the same folder the manual dylib/framework importer uses.
+        let installedNames = installPayload(from: dataDir, into: destinationFolder)
+
+        return DebImportResult(installedNames: installedNames, unsupportedScriptLines: unsupportedLines)
+    }
+
+    // MARK: - Safe control-script subset
+    //
+    // We never execute postinst/preinst as shell scripts. We only recognize a
+    // small set of file operations (mv, cp, mkdir, ln -s) and apply just their
+    // effect against the extracted data.tar tree. Anything else is left
+    // un-run and reported back so the caller can warn the user.
+
+    private static func applyControlScript(_ script: String, dataRoot: URL) -> [String] {
+        var warnings: [String] = []
+        let fm = FileManager.default
+
+        for rawLine in script.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+
+            let tokens = shellSplit(line)
+            guard let cmdToken = tokens.first else { continue }
+            let cmd = (cmdToken as NSString).lastPathComponent
+
+            guard supportedScriptCommands.contains(cmd) else {
+                warnings.append(line)
+                continue
+            }
+
+            let flags = tokens.dropFirst().filter { $0.hasPrefix("-") }
+            let pathArgs = tokens.dropFirst().filter { !$0.hasPrefix("-") }.map { resolvePath($0, dataRoot: dataRoot) }
+
+            switch cmd {
+            case "mkdir":
+                guard !pathArgs.isEmpty else { warnings.append(line); continue }
+                for path in pathArgs {
+                    try? fm.createDirectory(at: path, withIntermediateDirectories: true)
+                }
+            case "mv":
+                guard pathArgs.count == 2 else { warnings.append(line); continue }
+                try? fm.removeItem(at: pathArgs[1])
+                try? fm.moveItem(at: pathArgs[0], to: pathArgs[1])
+            case "cp":
+                guard pathArgs.count == 2 else { warnings.append(line); continue }
+                try? fm.removeItem(at: pathArgs[1])
+                try? fm.copyItem(at: pathArgs[0], to: pathArgs[1])
+            case "ln":
+                guard flags.contains(where: { $0.contains("s") }), pathArgs.count == 2 else {
+                    warnings.append(line)
+                    continue
+                }
+                try? fm.removeItem(at: pathArgs[1])
+                try? fm.createSymbolicLink(at: pathArgs[1], withDestinationURL: pathArgs[0])
+            default:
+                break
+            }
+        }
+        return warnings
+    }
+
+    private static func resolvePath(_ raw: String, dataRoot: URL) -> URL {
+        var path = raw
+        if path.hasPrefix("\"") && path.hasSuffix("\"") && path.count >= 2 {
+            path = String(path.dropFirst().dropLast())
+        }
+        while path.hasPrefix("/") { path.removeFirst() }
+        return dataRoot.appendingPathComponent(path)
+    }
+
+    /// A deliberately crude tokenizer: it only understands plain words and
+    /// simple double-quoted arguments. Any line using shell features it
+    /// doesn't understand (pipes, substitution, conditionals, variables) is
+    /// turned into a single unrecognized token so the caller reports and
+    /// skips it instead of misinterpreting it.
+    private static func shellSplit(_ line: String) -> [String] {
+        if line.contains("|") || line.contains(";") || line.contains("&&") || line.contains("$") || line.contains("`") || line.contains("(") {
+            return ["__unsupported__"]
+        }
+        var tokens: [String] = []
+        var current = ""
+        var inQuotes = false
+        for ch in line {
+            if ch == "\"" {
+                inQuotes.toggle()
+                continue
+            }
+            if ch == " " && !inQuotes {
+                if !current.isEmpty { tokens.append(current); current = "" }
+                continue
+            }
+            current.append(ch)
+        }
+        if !current.isEmpty { tokens.append(current) }
+        return tokens
+    }
+
+    // MARK: - Payload layout remap
+
+    private static func pathEndsWith(_ url: URL, _ suffix: [String]) -> Bool {
+        let comps = url.pathComponents
+        guard comps.count >= suffix.count else { return false }
+        return zip(comps.suffix(suffix.count), suffix).allSatisfy { $0.caseInsensitiveCompare($1) == .orderedSame }
+    }
+
+    private static func installPayload(from dataRoot: URL, into destination: URL) -> [String] {
+        let fm = FileManager.default
+        var installed: [String] = []
+
+        var dynamicLibDirs: [URL] = []
+        var frameworksDirs: [URL] = []
+        var preferenceBundleDirs: [URL] = []
+
+        if let enumerator = fm.enumerator(at: dataRoot, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) {
+            for case let url as URL in enumerator {
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else { continue }
+                if pathEndsWith(url, dynamicLibrariesSuffix) {
+                    dynamicLibDirs.append(url)
+                } else if pathEndsWith(url, frameworksSuffix) {
+                    frameworksDirs.append(url)
+                } else if pathEndsWith(url, preferenceBundlesSuffix) {
+                    preferenceBundleDirs.append(url)
+                }
+            }
+        }
+
+        func install(_ itemUrl: URL, patchMachO: Bool) {
+            let dest = destination.appendingPathComponent(itemUrl.lastPathComponent)
+            if fm.fileExists(atPath: dest.path) {
+                try? fm.removeItem(at: dest)
+            }
+            do {
+                try fm.copyItem(at: itemUrl, to: dest)
+            } catch {
+                NSLog("[LC] deb import: failed to install \(itemUrl.lastPathComponent): \(error)")
+                return
+            }
+            if patchMachO {
+                patchRPath(at: dest)
+            }
+            installed.append(itemUrl.lastPathComponent)
+        }
+
+        for dir in dynamicLibDirs {
+            let children = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+            for child in children {
+                let ext = child.pathExtension.lowercased()
+                guard ext == "dylib" || ext == "plist" else { continue }
+                install(child, patchMachO: ext == "dylib")
+            }
+        }
+        for dir in frameworksDirs {
+            let children = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+            for child in children where child.pathExtension.lowercased() == "framework" {
+                install(child, patchMachO: true)
+            }
+        }
+        for dir in preferenceBundleDirs {
+            let children = (try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)) ?? []
+            for child in children where child.pathExtension.lowercased() == "bundle" {
+                install(child, patchMachO: false)
+            }
+        }
+
+        return installed
+    }
+
+    // Same rpath fixup manual dylib/framework import already applies before signing.
+    private static func patchRPath(at url: URL) {
+        var machOUrl = url
+        if url.pathExtension.lowercased() == "framework" {
+            let info = NSDictionary(contentsOf: url.appendingPathComponent("Info.plist"))
+            let execName = (info?["CFBundleExecutable"] as? String) ?? url.deletingPathExtension().lastPathComponent
+            machOUrl = url.appendingPathComponent(execName)
+        }
+        guard FileManager.default.fileExists(atPath: machOUrl.path) else { return }
+        LCParseMachO((machOUrl.path as NSString).utf8String, false) { path, header, _, _ in
+            LCPatchAddRPath(path, header)
+        }
+    }
+}

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -28,39 +28,11 @@ extension LCUtils {
         }
         
         // check if re-sign is needed
-        // if signature is invalid, we need to re-sign. dylib and framework's main binary are supported
-        let fileURLs = try fm.contentsOfDirectory(at: tweakFolderUrl, includingPropertiesForKeys: nil)
+        // if signature is invalid, we need to re-sign. dylib and framework's main binary are supported.
+        // Plain subfolders (manually-organized tweaks, or a deb-imported tweak's own folder) are
+        // recursed into so nested dylibs/frameworks get signed too.
+        let filesToSign = collectFilesToSign(in: tweakFolderUrl, force: force, fm: fm)
 
-        var filesToSign: [URL] = []
-        
-        for fileURL in fileURLs {
-            var fileURL = fileURL
-            let attributes = try fm.attributesOfItem(atPath: fileURL.path)
-            let fileType = attributes[.type] as? FileAttributeType
-            if(fileType != FileAttributeType.typeDirectory && fileType != FileAttributeType.typeRegular) {
-                continue
-            }
-            let name = fileURL.lastPathComponent
-            let baseName = name.hasSuffix(".disabled") ? String(name.dropLast(".disabled".count)) : name
-            if(fileType == FileAttributeType.typeDirectory) {
-                if(!baseName.hasSuffix(".framework")) {
-                    continue
-                }
-                guard let frameworkBundle = Bundle(url: fileURL), let executableURL = frameworkBundle.executableURL else {
-                    continue
-                }
-                fileURL = executableURL
-            } else if (fileType == FileAttributeType.typeRegular && !baseName.hasSuffix(".dylib")) {
-                continue
-            }
-
-            if !force, checkCodeSignature((fileURL.path as NSString).utf8String) {
-                continue;
-            }
-            
-            filesToSign.append(fileURL)
-        }
-        
         if filesToSign.isEmpty {
             return
         }
@@ -87,7 +59,45 @@ extension LCUtils {
             }
         })
     }
-        
+
+    private static func collectFilesToSign(in folderUrl: URL, force: Bool, fm: FileManager) -> [URL] {
+        guard let fileURLs = try? fm.contentsOfDirectory(at: folderUrl, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        var result: [URL] = []
+        for fileURL in fileURLs {
+            var fileURL = fileURL
+            guard let attributes = try? fm.attributesOfItem(atPath: fileURL.path) else { continue }
+            let fileType = attributes[.type] as? FileAttributeType
+            guard fileType == .typeDirectory || fileType == .typeRegular else { continue }
+
+            let name = fileURL.lastPathComponent
+            let baseName = name.hasSuffix(".disabled") ? String(name.dropLast(".disabled".count)) : name
+
+            if fileType == .typeDirectory {
+                if baseName.hasSuffix(".framework") {
+                    guard let frameworkBundle = Bundle(url: fileURL), let executableURL = frameworkBundle.executableURL else {
+                        continue
+                    }
+                    fileURL = executableURL
+                } else {
+                    // a plain organizational/tweak subfolder -- recurse, unless disabled as a whole
+                    if name.hasSuffix(".disabled") { continue }
+                    result.append(contentsOf: collectFilesToSign(in: fileURL, force: force, fm: fm))
+                    continue
+                }
+            } else if !baseName.hasSuffix(".dylib") {
+                continue
+            }
+
+            if !force, checkCodeSignature((fileURL.path as NSString).utf8String) {
+                continue
+            }
+            result.append(fileURL)
+        }
+        return result
+    }
+
     private static func authenticateUser(completion: @escaping (Bool, Error?) -> Void) {
         // Create a context for authentication
         let context = LAContext()

--- a/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
+++ b/LiveContainerSwiftUI/Utilities/LCUtilsExtensions.swift
@@ -61,7 +61,11 @@ extension LCUtils {
     }
 
     private static func collectFilesToSign(in folderUrl: URL, force: Bool, fm: FileManager) -> [URL] {
-        guard let fileURLs = try? fm.contentsOfDirectory(at: folderUrl, includingPropertiesForKeys: nil) else {
+        // .skipsHiddenFiles keeps this from walking into DebImporter's own bookkeeping
+        // (.lc_shared_jbroot in particular, a flat mirror of every deb-imported tweak's
+        // frameworks/bundles as symlinks -- every leaf there ends up filtered out below
+        // anyway, but not before the whole tree is walked and stat'd for nothing).
+        guard let fileURLs = try? fm.contentsOfDirectory(at: folderUrl, includingPropertiesForKeys: nil, options: .skipsHiddenFiles) else {
             return []
         }
         var result: [URL] = []

--- a/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
@@ -39,7 +39,18 @@ struct LCAppSettingsView: View {
     @State private var selectUnusedContainerSheetShow = false
     
     @EnvironmentObject private var sharedModel : SharedModel
-    
+
+    // A deb-imported folder sitting at the top level of Tweaks/ already loads for every
+    // app (see TweakLoader.m's global-tweaks loop), so offering it here -- where picking
+    // one is supposed to scope a tweak to just this app -- would be misleading: selecting
+    // it wouldn't actually make it private to this app, since it's already active
+    // everywhere. Only plain, user-created folders are meaningful choices here.
+    private var selectableTweakFolderNames: [String] {
+        sharedModel.tweakFolderNames.filter { name in
+            !FileManager.default.fileExists(atPath: LCPath.tweakPath.appendingPathComponent(name).appendingPathComponent(DebImporter.debTweakMarkerName).path)
+        }
+    }
+
     init(model: LCAppModel) {
         self.appInfo = model.appInfo
         self._model = ObservedObject(wrappedValue: model)
@@ -67,7 +78,7 @@ struct LCAppSettingsView: View {
                     Menu {
                         Picker(selection: $model.uiTweakFolder , label: Text("")) {
                             Label("lc.common.none".loc, systemImage: "nosign").tag(Optional<String>(nil))
-                            ForEach(sharedModel.tweakFolderNames, id:\.self) { folderName in
+                            ForEach(selectableTweakFolderNames, id:\.self) { folderName in
                                 Text(folderName).tag(Optional(folderName))
                             }
                         }

--- a/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
+++ b/LiveContainerSwiftUI/Views/AppList/AppSettings/LCAppSettingsView.swift
@@ -46,8 +46,18 @@ struct LCAppSettingsView: View {
     // it wouldn't actually make it private to this app, since it's already active
     // everywhere. Only plain, user-created folders are meaningful choices here.
     private var selectableTweakFolderNames: [String] {
-        sharedModel.tweakFolderNames.filter { name in
-            !FileManager.default.fileExists(atPath: LCPath.tweakPath.appendingPathComponent(name).appendingPathComponent(DebImporter.debTweakMarkerName).path)
+        let fm = FileManager.default
+        return sharedModel.tweakFolderNames.filter { name in
+            // sharedModel.tweakFolderNames has the ".disabled" suffix already stripped off
+            // (LiveContainerSwiftUIApp.swift), but the folder on disk keeps it while
+            // disabled -- probe both so a disabled deb-imported folder doesn't slip past
+            // this filter just because the plain name doesn't exist right now.
+            for candidate in [name, name + LCTweakItem.disabledSuffix] {
+                if fm.fileExists(atPath: LCPath.tweakPath.appendingPathComponent(candidate).appendingPathComponent(DebImporter.debTweakMarkerName).path) {
+                    return false
+                }
+            }
+            return true
         }
     }
 

--- a/LiveContainerSwiftUI/Views/LCTweaksView.swift
+++ b/LiveContainerSwiftUI/Views/LCTweaksView.swift
@@ -15,6 +15,13 @@ struct LCTweakItem : Hashable {
     let isFramework: Bool
     let isTweak: Bool
     let isEnabled: Bool
+    // Marked by DebImporter (.lc_deb_tweak) so this folder -- which mirrors a single
+    // imported .deb's own directory structure -- is visually distinct from a plain
+    // folder the user created themselves to group/select tweaks per-app, and so
+    // TweakLoader.m's "global tweaks" loop knows a top-level one of these should load
+    // for every app the same way a loose .dylib does, while a plain user-created
+    // folder should only load for an app that has explicitly selected it.
+    let isDebImportedTweak: Bool
 
     var displayName: String {
         let name = fileUrl.lastPathComponent
@@ -69,7 +76,9 @@ struct LCTweakFolderView : View {
             let baseName = isEnabled ? fileName : String(fileName.dropLast(LCTweakItem.disabledSuffix.count))
             let isFramework = isFolder.boolValue && baseName.hasSuffix(".framework")
             let isTweak = !isFolder.boolValue && baseName.hasSuffix(".dylib")
-            tmpTweakItems.append(LCTweakItem(fileUrl: fileUrl, isFolder: isFolder.boolValue, isFramework: isFramework, isTweak: isTweak, isEnabled: isEnabled))
+            let isDebImportedTweak = isFolder.boolValue && !isFramework &&
+                fm.fileExists(atPath: fileUrl.appendingPathComponent(DebImporter.debTweakMarkerName).path)
+            tmpTweakItems.append(LCTweakItem(fileUrl: fileUrl, isFolder: isFolder.boolValue, isFramework: isFramework, isTweak: isTweak, isEnabled: isEnabled, isDebImportedTweak: isDebImportedTweak))
         }
         return tmpTweakItems
     }
@@ -90,7 +99,7 @@ struct LCTweakFolderView : View {
                                     }
                                     .opacity(0)
                                     HStack {
-                                        Label(tweakItem.displayName, systemImage: "folder.fill")
+                                        Label(tweakItem.displayName, systemImage: tweakItem.isDebImportedTweak ? "shippingbox.fill" : "folder.fill")
                                         Spacer()
                                         Image(systemName: "chevron.forward")
                                             .font(.footnote.weight(.semibold))
@@ -249,7 +258,7 @@ struct LCTweakFolderView : View {
         guard let index = tweakItems.firstIndex(of: tweakItem) else {
             return
         }
-        tweakItems[index] = LCTweakItem(fileUrl: newUrl, isFolder: tweakItem.isFolder, isFramework: tweakItem.isFramework, isTweak: tweakItem.isTweak, isEnabled: enabled)
+        tweakItems[index] = LCTweakItem(fileUrl: newUrl, isFolder: tweakItem.isFolder, isFramework: tweakItem.isFramework, isTweak: tweakItem.isTweak, isEnabled: enabled, isDebImportedTweak: tweakItem.isDebImportedTweak)
     }
 
     func deleteTweakItem(indexSet: IndexSet) {
@@ -326,7 +335,7 @@ struct LCTweakFolderView : View {
             return
         }
         tweakItems.remove(at: indexToRename)
-        let newTweakItem = LCTweakItem(fileUrl: newUrl, isFolder: tweakItem.isFolder, isFramework: tweakItem.isFramework, isTweak: tweakItem.isTweak, isEnabled: tweakItem.isEnabled)
+        let newTweakItem = LCTweakItem(fileUrl: newUrl, isFolder: tweakItem.isFolder, isFramework: tweakItem.isFramework, isTweak: tweakItem.isTweak, isEnabled: tweakItem.isEnabled, isDebImportedTweak: tweakItem.isDebImportedTweak)
         tweakItems.insert(newTweakItem, at: indexToRename)
 
         if isRoot {
@@ -370,7 +379,7 @@ struct LCTweakFolderView : View {
             errorInfo = error.localizedDescription
             return
         }
-        tweakItems.append(LCTweakItem(fileUrl: dest, isFolder: true, isFramework: false, isTweak: false, isEnabled: true))
+        tweakItems.append(LCTweakItem(fileUrl: dest, isFolder: true, isFramework: false, isTweak: false, isEnabled: true, isDebImportedTweak: false))
         if isRoot {
             sharedModel.tweakFolderNames.append(newName)
         }
@@ -408,7 +417,7 @@ struct LCTweakFolderView : View {
 
                 let isFramework = toPath.lastPathComponent.hasSuffix(".framework")
                 let isTweak = toPath.lastPathComponent.hasSuffix(".dylib")
-                self.tweakItems.append(LCTweakItem(fileUrl: toPath, isFolder: false, isFramework: isFramework, isTweak: isTweak, isEnabled: true))
+                self.tweakItems.append(LCTweakItem(fileUrl: toPath, isFolder: false, isFramework: isFramework, isTweak: isTweak, isEnabled: true, isDebImportedTweak: false))
             }
 
             // a .deb can drop multiple items (dylib + plist, a framework, a bundle),

--- a/LiveContainerSwiftUI/Views/LCTweaksView.swift
+++ b/LiveContainerSwiftUI/Views/LCTweaksView.swift
@@ -69,6 +69,11 @@ struct LCTweakFolderView : View {
         let fm = FileManager()
         let files = try fm.contentsOfDirectory(atPath: baseUrl.path)
         for fileName in files {
+            // DebImporter's own bookkeeping (.lc_deb_redirects.plist, .lc_shared_jbroot)
+            // lives alongside the tweaks it manages rather than in a separate config
+            // location, but it isn't a tweak itself -- keep it out of the list the user
+            // browses/imports/deletes tweaks from.
+            if fileName.hasPrefix(".") { continue }
             let fileUrl = baseUrl.appendingPathComponent(fileName)
             var isFolder : ObjCBool = false
             fm.fileExists(atPath: fileUrl.path, isDirectory: &isFolder)

--- a/LiveContainerSwiftUI/Views/LCTweaksView.swift
+++ b/LiveContainerSwiftUI/Views/LCTweaksView.swift
@@ -273,6 +273,9 @@ struct LCTweakFolderView : View {
             for i in indexSet {
                 let tweakItem = tweakItems[i]
                 try fm.removeItem(at: tweakItem.fileUrl)
+                if tweakItem.isDebImportedTweak {
+                    DebImporter.removeTweak(named: tweakItem.displayName, from: baseUrl)
+                }
                 indexToRemove.append(i)
             }
         } catch {
@@ -297,6 +300,9 @@ struct LCTweakFolderView : View {
         do {
 
             try fm.removeItem(at: tweakItem.fileUrl)
+            if tweakItem.isDebImportedTweak {
+                DebImporter.removeTweak(named: tweakItem.displayName, from: baseUrl)
+            }
             indexToRemove = tweakItems.firstIndex(where: { s in
                 return s == tweakItem
             })
@@ -408,7 +414,7 @@ struct LCTweakFolderView : View {
                         debWarnings.append(contentsOf: result.unsupportedScriptLines)
                         didImportDeb = true
                     } catch {
-                        throw "lc.tweakView.debImportError %@".localizeWithFormat(fileUrl.lastPathComponent)
+                        throw "lc.tweakView.debImportError %@".localizeWithFormat("\(fileUrl.lastPathComponent): \(error.localizedDescription)")
                     }
                     try? fm.removeItem(at: fileUrl)
                     continue

--- a/LiveContainerSwiftUI/Views/LCTweaksView.swift
+++ b/LiveContainerSwiftUI/Views/LCTweaksView.swift
@@ -38,33 +38,40 @@ struct LCTweakFolderView : View {
     @StateObject private var renameFileInput = InputHelper()
     
     @State private var choosingTweak = false
-    
+
     @State private var isTweakSigning = false
-    
+
+    @State private var debWarningShow = false
+    @State private var debWarningInfo = ""
+
     init(baseUrl: URL, isRoot: Bool = false) {
         _baseUrl = State(initialValue: baseUrl)
         self.isRoot = isRoot
-        var tmpTweakItems : [LCTweakItem] = []
-        let fm = FileManager()
         do {
-            let files = try fm.contentsOfDirectory(atPath: baseUrl.path)
-            for fileName in files {
-                let fileUrl = baseUrl.appendingPathComponent(fileName)
-                var isFolder : ObjCBool = false
-                fm.fileExists(atPath: fileUrl.path, isDirectory: &isFolder)
-                let isEnabled = !fileName.hasSuffix(LCTweakItem.disabledSuffix)
-                let baseName = isEnabled ? fileName : String(fileName.dropLast(LCTweakItem.disabledSuffix.count))
-                let isFramework = isFolder.boolValue && baseName.hasSuffix(".framework")
-                let isTweak = !isFolder.boolValue && baseName.hasSuffix(".dylib")
-                tmpTweakItems.append(LCTweakItem(fileUrl: fileUrl, isFolder: isFolder.boolValue, isFramework: isFramework, isTweak: isTweak, isEnabled: isEnabled))
-            }
-            _tweakItems = State(initialValue: tmpTweakItems)
+            _tweakItems = State(initialValue: try LCTweakFolderView.scanTweakItems(at: baseUrl))
         } catch {
             NSLog("[LC] failed to load tweaks \(error.localizedDescription)")
             _errorShow = State(initialValue: true)
             _errorInfo = State(initialValue: error.localizedDescription)
             _tweakItems = State(initialValue: [])
         }
+    }
+
+    static func scanTweakItems(at baseUrl: URL) throws -> [LCTweakItem] {
+        var tmpTweakItems : [LCTweakItem] = []
+        let fm = FileManager()
+        let files = try fm.contentsOfDirectory(atPath: baseUrl.path)
+        for fileName in files {
+            let fileUrl = baseUrl.appendingPathComponent(fileName)
+            var isFolder : ObjCBool = false
+            fm.fileExists(atPath: fileUrl.path, isDirectory: &isFolder)
+            let isEnabled = !fileName.hasSuffix(LCTweakItem.disabledSuffix)
+            let baseName = isEnabled ? fileName : String(fileName.dropLast(LCTweakItem.disabledSuffix.count))
+            let isFramework = isFolder.boolValue && baseName.hasSuffix(".framework")
+            let isTweak = !isFolder.boolValue && baseName.hasSuffix(".dylib")
+            tmpTweakItems.append(LCTweakItem(fileUrl: fileUrl, isFolder: isFolder.boolValue, isFramework: isFramework, isTweak: isTweak, isEnabled: isEnabled))
+        }
+        return tmpTweakItems
     }
 
     var body: some View {
@@ -187,6 +194,12 @@ struct LCTweakFolderView : View {
         } message: {
             Text(errorInfo)
         }
+        .alert("lc.tweakView.debUnsupportedScriptTitle".loc, isPresented: $debWarningShow) {
+            Button("lc.common.ok".loc, action: {
+            })
+        } message: {
+            Text(debWarningInfo)
+        }
         .textFieldAlert(
             isPresented: $newFolderInput.show,
             title: "lc.common.enterNewFolderName".loc,
@@ -211,7 +224,7 @@ struct LCTweakFolderView : View {
                 renameFileInput.close(result: "")
             }
         )
-        .betterFileImporter(isPresented: $choosingTweak, types: [.dylib, .lcFramework, /*.deb*/], multiple: true, callback: { fileUrls in
+        .betterFileImporter(isPresented: $choosingTweak, types: [.dylib, .lcFramework, .deb], multiple: true, callback: { fileUrls in
             Task { await startInstallTweak(fileUrls) }
         }, onDismiss: {
             choosingTweak = false
@@ -364,15 +377,29 @@ struct LCTweakFolderView : View {
     }
     
     func startInstallTweak(_ urls: [URL]) async {
+        var debWarnings: [String] = []
+        var didImportDeb = false
         do {
             let fm = FileManager()
             // we will sign later before app launch
-            
+
             for fileUrl in urls {
-                // handle deb file
                 if(!fileUrl.isFileURL) {
                     throw "lc.tweakView.notFileError %@".localizeWithFormat(fileUrl.lastPathComponent)
                 }
+
+                if fileUrl.pathExtension.lowercased() == "deb" {
+                    do {
+                        let result = try DebImporter.importDeb(at: fileUrl, into: self.baseUrl)
+                        debWarnings.append(contentsOf: result.unsupportedScriptLines)
+                        didImportDeb = true
+                    } catch {
+                        throw "lc.tweakView.debImportError %@".localizeWithFormat(fileUrl.lastPathComponent)
+                    }
+                    try? fm.removeItem(at: fileUrl)
+                    continue
+                }
+
                 let toPath = self.baseUrl.appendingPathComponent(fileUrl.lastPathComponent)
                 try fm.moveItem(at: fileUrl, to: toPath)
                 LCParseMachO((toPath.path as NSString).utf8String, false) { path, header, _, _ in
@@ -383,10 +410,21 @@ struct LCTweakFolderView : View {
                 let isTweak = toPath.lastPathComponent.hasSuffix(".dylib")
                 self.tweakItems.append(LCTweakItem(fileUrl: toPath, isFolder: false, isFramework: isFramework, isTweak: isTweak, isEnabled: true))
             }
+
+            // a .deb can drop multiple items (dylib + plist, a framework, a bundle),
+            // so re-scan the folder from disk rather than tracking them one by one
+            if didImportDeb {
+                tweakItems = try LCTweakFolderView.scanTweakItems(at: baseUrl)
+            }
         } catch {
             errorInfo = error.localizedDescription
-            errorShow = true            
+            errorShow = true
             return
+        }
+
+        if !debWarnings.isEmpty {
+            debWarningInfo = "lc.tweakView.debUnsupportedScriptMsg %@".localizeWithFormat(debWarnings.joined(separator: "\n"))
+            debWarningShow = true
         }
     }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -32004,6 +32004,39 @@
         }
       }
     },
+    "lc.tweakView.debImportError %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to import %@: not a valid .deb package."
+          }
+        }
+      }
+    },
+    "lc.tweakView.debUnsupportedScriptTitle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unsupported Setup Steps"
+          }
+        }
+      }
+    },
+    "lc.tweakView.debUnsupportedScriptMsg %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This tweak's install script contains steps LiveContainer doesn't support, so they were skipped:\n%@"
+          }
+        }
+      }
+    },
     "lc.utils.initSigningError" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/TweakLoader/DebPathRedirect.h
+++ b/TweakLoader/DebPathRedirect.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+// Rewrites hardcoded absolute paths that deb-imported tweaks use to find their own
+// resource bundles/frameworks (e.g. /Library/Application Support/Foo.bundle,
+// /var/jb/Library/Frameworks/Foo.framework) to wherever DebImporter actually placed
+// them on disk, so NSBundle/CFBundle/open() lookups made by the tweak's own code
+// still resolve inside LiveContainer's sandbox.
+void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath);

--- a/TweakLoader/DebPathRedirect.h
+++ b/TweakLoader/DebPathRedirect.h
@@ -5,4 +5,9 @@
 // /var/jb/Library/Frameworks/Foo.framework) to wherever DebImporter actually placed
 // them on disk, so NSBundle/CFBundle/open() lookups made by the tweak's own code
 // still resolve inside LiveContainer's sandbox.
-void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath);
+// isGroupTweakFolder tells us which of the two physical tweak-folder roots
+// globalTweakFolder actually is this launch (LCPath.tweakPath vs
+// LCPath.lcGroupTweakPath) -- redirect data is stored in NSUserDefaults keyed
+// separately per root, since the same launch's globalTweakFolder never points at
+// both at once, but a device can have deb-imported tweaks recorded under either.
+void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath, BOOL isGroupTweakFolder);

--- a/TweakLoader/DebPathRedirect.h
+++ b/TweakLoader/DebPathRedirect.h
@@ -5,9 +5,4 @@
 // /var/jb/Library/Frameworks/Foo.framework) to wherever DebImporter actually placed
 // them on disk, so NSBundle/CFBundle/open() lookups made by the tweak's own code
 // still resolve inside LiveContainer's sandbox.
-// isGroupTweakFolder tells us which of the two physical tweak-folder roots
-// globalTweakFolder actually is this launch (LCPath.tweakPath vs
-// LCPath.lcGroupTweakPath) -- redirect data is stored in NSUserDefaults keyed
-// separately per root, since the same launch's globalTweakFolder never points at
-// both at once, but a device can have deb-imported tweaks recorded under either.
-void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath, BOOL isGroupTweakFolder);
+void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath);

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -21,8 +21,39 @@ static NSUInteger sRedirectCount = 0;
 static LCDebRedirect *sIdentifierRedirects = NULL;
 static NSUInteger sIdentifierRedirectCount = 0;
 
+// TEMPORARY DIAGNOSTIC ONLY -- remove once the bundle-loading issue is confirmed fixed.
+// NSLog/os_log redact string arguments by default and no available syslog client could
+// decode the {public} privacy override cleanly, so diagnostics are buffered in memory and
+// dumped via a deliberate uncaught exception once activity quiets down (debounced 6s after
+// the last log line). LCBootstrap.m's existing NSSetUncaughtExceptionHandler catches it and
+// stores the reason under "error" in UserDefaults; LCTabView.swift shows that as a copyable
+// crash-report sheet next time LiveContainer's own UI (not the guest app) is opened.
+static NSMutableArray<NSString *> *sDiagnosticLines;
+static NSObject *sDiagnosticLock;
+static NSUInteger sDiagnosticGeneration;
+
+static void scheduleDiagnosticsDump(void) {
+    NSUInteger myGeneration = ++sDiagnosticGeneration;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (myGeneration != sDiagnosticGeneration) return; // superseded by more recent activity
+        NSString *dump = [sDiagnosticLines componentsJoinedByString:@"\n"];
+        [NSException raise:@"LCDebPathRedirectDiagnostics" format:@"%@", dump];
+    });
+}
+
+static void lclog(NSString *msg) {
+    if (!sDiagnosticLock) sDiagnosticLock = [NSObject new];
+    @synchronized (sDiagnosticLock) {
+        if (!sDiagnosticLines) sDiagnosticLines = [NSMutableArray new];
+        [sDiagnosticLines addObject:msg];
+    }
+    NSLog(@"%@", msg);
+    scheduleDiagnosticsDump();
+}
+
 static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable"]);
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
@@ -41,6 +72,7 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
+            lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: %s -> %s", path, buffer]);
             return buffer;
         }
     }
@@ -87,26 +119,32 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSBundle (LCDebRedirect)
 
 + (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%@]", path]);
     return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
 - (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithPath:%@]", path]);
     return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%@]", url]);
     return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
 - (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithURL:%@]", url]);
     return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithIdentifier:(NSString *)identifier {
     NSBundle *result = [self lc_debRedirect_bundleWithIdentifier:identifier];
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%@] -> %@", identifier, result]);
     if (result) return result;
     const char *path = lookupIdentifierRedirect(identifier.UTF8String);
     if (path) {
+        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: bundleWithIdentifier fallback %@ -> %s", identifier, path]);
         return [NSBundle bundleWithPath:[NSString stringWithUTF8String:path]];
     }
     return result;
@@ -120,11 +158,21 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSFileManager (LCDebRedirect)
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path {
-    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path)];
+    NSString *rewritten = lc_debRewritePath(path);
+    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten];
+    if (![path isEqualToString:rewritten]) {
+        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@] (rewritten=%@) -> %d", path, rewritten, result]);
+    }
+    return result;
 }
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path isDirectory:(BOOL *)isDirectory {
-    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path) isDirectory:isDirectory];
+    NSString *rewritten = lc_debRewritePath(path);
+    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten isDirectory:isDirectory];
+    if (![path isEqualToString:rewritten]) {
+        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@ isDirectory:] (rewritten=%@) -> %d", path, rewritten, result]);
+    }
+    return result;
 }
 
 - (NSArray<NSString *> *)lc_debRedirect_contentsOfDirectoryAtPath:(NSString *)path error:(NSError **)error {
@@ -134,6 +182,11 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
+    // TEMPORARY DIAGNOSTIC ONLY -- scheduled unconditionally, up front, so we get a
+    // crash-report dump of everything logged below no matter which path this takes.
+    scheduleDiagnosticsDump();
+
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath]);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
         loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
@@ -141,6 +194,7 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     if (selectedTweakFolderPath) {
         loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
     }
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged]);
     if (merged.count == 0) return;
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -1,0 +1,124 @@
+#import "DebPathRedirect.h"
+#include "../litehook/src/litehook.h"
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+// Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
+// compiled-in strings might reference (e.g. "/Library/Application Support/Foo.bundle"
+// or "/var/jb/Library/Frameworks/Foo.framework") to where DebImporter.swift actually
+// put that resource inside the LiveContainer tweak folder.
+typedef struct {
+    char *from;
+    size_t fromLen;
+    char *to;
+} LCDebRedirect;
+
+static LCDebRedirect *sRedirects = NULL;
+static NSUInteger sRedirectCount = 0;
+
+static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
+    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+    if (![dict isKindOfClass:NSDictionary.class]) return;
+    for (NSString *from in dict) {
+        id to = dict[from];
+        if ([from isKindOfClass:NSString.class] && [to isKindOfClass:NSString.class]) {
+            merged[from] = to;
+        }
+    }
+}
+
+static const char *rewritePath(const char *path) {
+    if (!path || sRedirectCount == 0) return path;
+    size_t pathLen = strlen(path);
+    for (NSUInteger i = 0; i < sRedirectCount; i++) {
+        LCDebRedirect *r = &sRedirects[i];
+        if (pathLen >= r->fromLen && memcmp(path, r->from, r->fromLen) == 0 &&
+            (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
+            static __thread char buffer[PATH_MAX];
+            snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
+            return buffer;
+        }
+    }
+    return path;
+}
+
+static int (*orig_open)(const char *, int, ...) = open;
+static int lc_open(const char *path, int oflag, ...) {
+    mode_t mode = 0;
+    if (oflag & O_CREAT) {
+        va_list args;
+        va_start(args, oflag);
+        mode = (mode_t)va_arg(args, int);
+        va_end(args);
+        return orig_open(rewritePath(path), oflag, mode);
+    }
+    return orig_open(rewritePath(path), oflag);
+}
+
+static int (*orig_stat)(const char *, struct stat *) = stat;
+static int lc_stat(const char *path, struct stat *buf) {
+    return orig_stat(rewritePath(path), buf);
+}
+
+static int (*orig_lstat)(const char *, struct stat *) = lstat;
+static int lc_lstat(const char *path, struct stat *buf) {
+    return orig_lstat(rewritePath(path), buf);
+}
+
+static int (*orig_access)(const char *, int) = access;
+static int lc_access(const char *path, int mode) {
+    return orig_access(rewritePath(path), mode);
+}
+
+static char *(*orig_realpath)(const char *, char *) = realpath;
+static char *lc_realpath(const char *path, char *resolved) {
+    return orig_realpath(rewritePath(path), resolved);
+}
+
+static FILE *(*orig_fopen)(const char *, const char *) = fopen;
+static FILE *lc_fopen(const char *path, const char *mode) {
+    return orig_fopen(rewritePath(path), mode);
+}
+
+static DIR *(*orig_opendir)(const char *) = opendir;
+static DIR *lc_opendir(const char *path) {
+    return orig_opendir(rewritePath(path));
+}
+
+void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
+    NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
+    if (globalTweakFolder) {
+        loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
+    }
+    if (selectedTweakFolderPath) {
+        loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
+    }
+    if (merged.count == 0) return;
+
+    sRedirectCount = merged.count;
+    sRedirects = calloc(sRedirectCount, sizeof(LCDebRedirect));
+    NSUInteger i = 0;
+    for (NSString *from in merged) {
+        sRedirects[i].from = strdup(from.fileSystemRepresentation);
+        sRedirects[i].fromLen = strlen(sRedirects[i].from);
+        sRedirects[i].to = strdup(merged[from].fileSystemRepresentation);
+        i++;
+    }
+    // longest (most specific) prefix first, so a nested path never matches a shorter parent by accident
+    qsort_b(sRedirects, sRedirectCount, sizeof(LCDebRedirect), ^int(const void *a, const void *b) {
+        return (int)(((const LCDebRedirect *)b)->fromLen - ((const LCDebRedirect *)a)->fromLen);
+    });
+
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, open, lc_open, nil);
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, stat, lc_stat, nil);
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, lstat, lc_lstat, nil);
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, access, lc_access, nil);
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, realpath, lc_realpath, nil);
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, fopen, lc_fopen, nil);
+    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, opendir, lc_opendir, nil);
+}

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -21,36 +21,6 @@ static NSUInteger sRedirectCount = 0;
 static LCDebRedirect *sIdentifierRedirects = NULL;
 static NSUInteger sIdentifierRedirectCount = 0;
 
-// TEMPORARY DIAGNOSTIC ONLY -- remove once the bundle-loading issue is confirmed fixed.
-// NSLog/os_log redact string arguments by default and no available syslog client could
-// decode the {public} privacy override cleanly, so diagnostics are buffered in memory and
-// dumped via a deliberate uncaught exception once activity quiets down (debounced 6s after
-// the last log line). LCBootstrap.m's existing NSSetUncaughtExceptionHandler catches it and
-// stores the reason under "error" in UserDefaults; LCTabView.swift shows that as a copyable
-// crash-report sheet next time LiveContainer's own UI (not the guest app) is opened.
-static NSMutableArray<NSString *> *sDiagnosticLines;
-static NSObject *sDiagnosticLock;
-static NSUInteger sDiagnosticGeneration;
-
-static void scheduleDiagnosticsDump(void) {
-    NSUInteger myGeneration = ++sDiagnosticGeneration;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (myGeneration != sDiagnosticGeneration) return; // superseded by more recent activity
-        NSString *dump = [sDiagnosticLines componentsJoinedByString:@"\n"];
-        [NSException raise:@"LCDebPathRedirectDiagnostics" format:@"%@", dump];
-    });
-}
-
-static void lclog(NSString *msg) {
-    if (!sDiagnosticLock) sDiagnosticLock = [NSObject new];
-    @synchronized (sDiagnosticLock) {
-        if (!sDiagnosticLines) sDiagnosticLines = [NSMutableArray new];
-        [sDiagnosticLines addObject:msg];
-    }
-    NSLog(@"%@", msg);
-    scheduleDiagnosticsDump();
-}
-
 // Values in the plist are stored relative to baseFolder (the tweak-folder root the plist
 // itself lives in), not as absolute paths -- that root can move (LiveContainer reinstalled
 // with a new sandbox container UUID, or the tweak folder relocated by "convert to shared"),
@@ -59,7 +29,6 @@ static void lclog(NSString *msg) {
 // side of this.
 static void loadRedirectsFromPlist(NSString *plistPath, NSString *baseFolder, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable"]);
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
@@ -78,7 +47,6 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: %s -> %s", path, buffer]);
             return buffer;
         }
     }
@@ -125,32 +93,26 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSBundle (LCDebRedirect)
 
 + (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%@]", path]);
     return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
 - (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithPath:%@]", path]);
     return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%@]", url]);
     return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
 - (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithURL:%@]", url]);
     return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithIdentifier:(NSString *)identifier {
     NSBundle *result = [self lc_debRedirect_bundleWithIdentifier:identifier];
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%@] -> %@", identifier, result]);
     if (result) return result;
     const char *path = lookupIdentifierRedirect(identifier.UTF8String);
     if (path) {
-        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: bundleWithIdentifier fallback %@ -> %s", identifier, path]);
         return [NSBundle bundleWithPath:[NSString stringWithUTF8String:path]];
     }
     return result;
@@ -164,21 +126,11 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSFileManager (LCDebRedirect)
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path {
-    NSString *rewritten = lc_debRewritePath(path);
-    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten];
-    if (![path isEqualToString:rewritten]) {
-        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@] (rewritten=%@) -> %d", path, rewritten, result]);
-    }
-    return result;
+    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path)];
 }
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path isDirectory:(BOOL *)isDirectory {
-    NSString *rewritten = lc_debRewritePath(path);
-    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten isDirectory:isDirectory];
-    if (![path isEqualToString:rewritten]) {
-        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@ isDirectory:] (rewritten=%@) -> %d", path, rewritten, result]);
-    }
-    return result;
+    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path) isDirectory:isDirectory];
 }
 
 - (NSArray<NSString *> *)lc_debRedirect_contentsOfDirectoryAtPath:(NSString *)path error:(NSError **)error {
@@ -188,11 +140,6 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
-    // TEMPORARY DIAGNOSTIC ONLY -- scheduled unconditionally, up front, so we get a
-    // crash-report dump of everything logged below no matter which path this takes.
-    scheduleDiagnosticsDump();
-
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath]);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
         loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], globalTweakFolder, merged);
@@ -200,7 +147,6 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     if (selectedTweakFolderPath) {
         loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], selectedTweakFolderPath, merged);
     }
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged]);
     if (merged.count == 0) return;
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -1,12 +1,8 @@
 #import "DebPathRedirect.h"
-#include "../litehook/src/litehook.h"
-#include <dirent.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
+#import "../LiveContainer/utils.h"
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
 // compiled-in strings might reference (e.g. "/Library/Application Support/Foo.bundle"
@@ -47,48 +43,71 @@ static const char *rewritePath(const char *path) {
     return path;
 }
 
-static int (*orig_open)(const char *, int, ...) = open;
-static int lc_open(const char *path, int oflag, ...) {
-    mode_t mode = 0;
-    if (oflag & O_CREAT) {
-        va_list args;
-        va_start(args, oflag);
-        mode = (mode_t)va_arg(args, int);
-        va_end(args);
-        return orig_open(rewritePath(path), oflag, mode);
-    }
-    return orig_open(rewritePath(path), oflag);
+// NSBundle/CFBundle and NSFileManager do their actual filesystem work (stat/open) from
+// inside CoreFoundation/Foundation, which live in the dyld shared cache -- calls a shared
+// cache image makes to another shared cache image aren't interposable by rebinding a plain
+// C symbol like open()/stat(), since the cache uses direct, pre-bound stubs for those
+// intra-cache calls. Objective-C method dispatch isn't affected by that: it always goes
+// through the class's method list, so swizzling the handful of NSBundle/NSFileManager
+// entry points a tweak's own (non-cache) code calls into is what actually reaches these
+// calls, the same way NSBundle+FixCydiaSubstrate.m and NSFileManager+GuestHooks.m already
+// swizzle Foundation methods elsewhere in this codebase.
+static NSString *lc_debRewritePath(NSString *path) {
+    if (!path) return path;
+    const char *original = path.fileSystemRepresentation;
+    const char *rewritten = rewritePath(original);
+    if (rewritten == original) return path;
+    return [NSString stringWithUTF8String:rewritten];
 }
 
-static int (*orig_stat)(const char *, struct stat *) = stat;
-static int lc_stat(const char *path, struct stat *buf) {
-    return orig_stat(rewritePath(path), buf);
+static NSURL *lc_debRewriteFileURL(NSURL *url) {
+    if (!url || !url.isFileURL) return url;
+    NSString *rewritten = lc_debRewritePath(url.path);
+    if ([rewritten isEqualToString:url.path]) return url;
+    return [NSURL fileURLWithPath:rewritten];
 }
 
-static int (*orig_lstat)(const char *, struct stat *) = lstat;
-static int lc_lstat(const char *path, struct stat *buf) {
-    return orig_lstat(rewritePath(path), buf);
+@interface NSBundle (LCDebRedirect)
+@end
+
+@implementation NSBundle (LCDebRedirect)
+
++ (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
+    return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
-static int (*orig_access)(const char *, int) = access;
-static int lc_access(const char *path, int mode) {
-    return orig_access(rewritePath(path), mode);
+- (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
+    return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
-static char *(*orig_realpath)(const char *, char *) = realpath;
-static char *lc_realpath(const char *path, char *resolved) {
-    return orig_realpath(rewritePath(path), resolved);
++ (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
+    return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
-static FILE *(*orig_fopen)(const char *, const char *) = fopen;
-static FILE *lc_fopen(const char *path, const char *mode) {
-    return orig_fopen(rewritePath(path), mode);
+- (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
+    return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
 }
 
-static DIR *(*orig_opendir)(const char *) = opendir;
-static DIR *lc_opendir(const char *path) {
-    return orig_opendir(rewritePath(path));
+@end
+
+@interface NSFileManager (LCDebRedirect)
+@end
+
+@implementation NSFileManager (LCDebRedirect)
+
+- (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path {
+    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path)];
 }
+
+- (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path isDirectory:(BOOL *)isDirectory {
+    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path) isDirectory:isDirectory];
+}
+
+- (NSArray<NSString *> *)lc_debRedirect_contentsOfDirectoryAtPath:(NSString *)path error:(NSError **)error {
+    return [self lc_debRedirect_contentsOfDirectoryAtPath:lc_debRewritePath(path) error:error];
+}
+
+@end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
@@ -114,11 +133,12 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
         return (int)(((const LCDebRedirect *)b)->fromLen - ((const LCDebRedirect *)a)->fromLen);
     });
 
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, open, lc_open, nil);
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, stat, lc_stat, nil);
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, lstat, lc_lstat, nil);
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, access, lc_access, nil);
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, realpath, lc_realpath, nil);
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, fopen, lc_fopen, nil);
-    litehook_rebind_symbol(LITEHOOK_REBIND_GLOBAL, opendir, lc_opendir, nil);
+    swizzleClassMethod(NSBundle.class, @selector(bundleWithPath:), @selector(lc_debRedirect_bundleWithPath:));
+    swizzle(NSBundle.class, @selector(initWithPath:), @selector(lc_debRedirect_initWithPath:));
+    swizzleClassMethod(NSBundle.class, @selector(bundleWithURL:), @selector(lc_debRedirect_bundleWithURL:));
+    swizzle(NSBundle.class, @selector(initWithURL:), @selector(lc_debRedirect_initWithURL:));
+
+    swizzle(NSFileManager.class, @selector(fileExistsAtPath:), @selector(lc_debRedirect_fileExistsAtPath:));
+    swizzle(NSFileManager.class, @selector(fileExistsAtPath:isDirectory:), @selector(lc_debRedirect_fileExistsAtPath:isDirectory:));
+    swizzle(NSFileManager.class, @selector(contentsOfDirectoryAtPath:error:), @selector(lc_debRedirect_contentsOfDirectoryAtPath:error:));
 }

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -1,8 +1,18 @@
 #import "DebPathRedirect.h"
 #import "../LiveContainer/utils.h"
 #include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+// NSLog/os_log redact %@ arguments as <private> by default, and the {public} privacy
+// annotation isn't reliably decoded by every syslog client -- write diagnostics straight
+// to stderr instead, which the system captures into the unified log verbatim, unredacted,
+// with no format-string decoding involved.
+static void lclog(NSString *msg) {
+    fprintf(stderr, "%s\n", msg.UTF8String);
+    fflush(stderr);
+}
 
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
 // compiled-in strings might reference (e.g. "/Library/Application Support/Foo.bundle"
@@ -23,7 +33,7 @@ static NSUInteger sIdentifierRedirectCount = 0;
 
 static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
-    NSLog(@"[LC] DebPathRedirect: reading %{public}@ -> %{public}@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable");
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable"]);
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
@@ -42,7 +52,8 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            NSLog(@"[LC] DebPathRedirect: %{public}s -> %{public}s", path, buffer);
+            fprintf(stderr, "[LC] DebPathRedirect: %s -> %s\n", path, buffer);
+            fflush(stderr);
             return buffer;
         }
     }
@@ -89,32 +100,32 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSBundle (LCDebRedirect)
 
 + (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
-    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%{public}@]", path);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%@]", path]);
     return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
 - (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
-    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithPath:%{public}@]", path);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithPath:%@]", path]);
     return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
-    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%{public}@]", url);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%@]", url]);
     return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
 - (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
-    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithURL:%{public}@]", url);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithURL:%@]", url]);
     return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithIdentifier:(NSString *)identifier {
     NSBundle *result = [self lc_debRedirect_bundleWithIdentifier:identifier];
-    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%{public}@] -> %{public}@", identifier, result);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%@] -> %@", identifier, result]);
     if (result) return result;
     const char *path = lookupIdentifierRedirect(identifier.UTF8String);
     if (path) {
-        NSLog(@"[LC] DebPathRedirect: bundleWithIdentifier fallback %{public}@ -> %{public}s", identifier, path);
+        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: bundleWithIdentifier fallback %@ -> %s", identifier, path]);
         return [NSBundle bundleWithPath:[NSString stringWithUTF8String:path]];
     }
     return result;
@@ -130,14 +141,14 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path {
     NSString *rewritten = lc_debRewritePath(path);
     BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten];
-    NSLog(@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%{public}@] (rewritten=%{public}@) -> %d", path, rewritten, result);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@] (rewritten=%@) -> %d", path, rewritten, result]);
     return result;
 }
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path isDirectory:(BOOL *)isDirectory {
     NSString *rewritten = lc_debRewritePath(path);
     BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten isDirectory:isDirectory];
-    NSLog(@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%{public}@ isDirectory:] (rewritten=%{public}@) -> %d", path, rewritten, result);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@ isDirectory:] (rewritten=%@) -> %d", path, rewritten, result]);
     return result;
 }
 
@@ -148,7 +159,7 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
-    NSLog(@"[LC] DebPathRedirect: init globalTweakFolder=%{public}@ selectedTweakFolderPath=%{public}@", globalTweakFolder, selectedTweakFolderPath);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath]);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
         loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
@@ -156,7 +167,7 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     if (selectedTweakFolderPath) {
         loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
     }
-    NSLog(@"[LC] DebPathRedirect: merged %lu entries: %{public}@", (unsigned long)merged.count, merged);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged]);
     if (merged.count == 0) return;
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];
@@ -200,5 +211,5 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     swizzle(NSFileManager.class, @selector(fileExistsAtPath:), @selector(lc_debRedirect_fileExistsAtPath:));
     swizzle(NSFileManager.class, @selector(fileExistsAtPath:isDirectory:), @selector(lc_debRedirect_fileExistsAtPath:isDirectory:));
     swizzle(NSFileManager.class, @selector(contentsOfDirectoryAtPath:error:), @selector(lc_debRedirect_contentsOfDirectoryAtPath:error:));
-    NSLog(@"[LC] DebPathRedirect: installed hooks (%lu path, %lu identifier redirects)", (unsigned long)sRedirectCount, (unsigned long)sIdentifierRedirectCount);
+    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: installed hooks (%lu path, %lu identifier redirects)", (unsigned long)sRedirectCount, (unsigned long)sIdentifierRedirectCount]);
 }

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -11,7 +11,7 @@
 // a single plain %s -- no object argument left for the logging system to redact or for a
 // client to mis-decode.
 static void lclog(NSString *msg) {
-    NSLog(@"%s", msg.UTF8String);
+    NSLog(@"%{public}s", msg.UTF8String);
 }
 
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
@@ -52,7 +52,7 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            NSLog(@"[LC] DebPathRedirect: %s -> %s", path, buffer);
+            NSLog(@"[LC] DebPathRedirect: %{public}s -> %{public}s", path, buffer);
             return buffer;
         }
     }

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -21,20 +21,50 @@ static NSUInteger sRedirectCount = 0;
 static LCDebRedirect *sIdentifierRedirects = NULL;
 static NSUInteger sIdentifierRedirectCount = 0;
 
-// Values in the plist are stored relative to baseFolder (the tweak-folder root the plist
-// itself lives in), not as absolute paths -- that root can move (LiveContainer reinstalled
-// with a new sandbox container UUID, or the tweak folder relocated by "convert to shared"),
-// so the absolute destination is reconstructed fresh against whichever root is current at
-// each launch instead of being baked in at import time. See DebImporter.swift for the write
-// side of this.
-static void loadRedirectsFromPlist(NSString *plistPath, NSString *baseFolder, NSMutableDictionary<NSString *, NSString *> *merged) {
-    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+// Redirect data lives in NSUserDefaults (the App Group suite this codebase already uses
+// for every other piece of persistent LiveContainer config) rather than a dotfile inside
+// the user-browsable Tweaks folder. DebImporter.swift writes one top-level key per
+// physical tweak-folder root (isGroupTweakFolder picks which), holding a dictionary of
+// scopes -- "" for the root's own (global) entries, or a per-app-selected folder's name --
+// each mapping a bare absolute path to a path *relative to that scope's own folder*. That
+// relative storage (rather than an absolute path baked in at import time) is what lets the
+// same entry keep resolving correctly however the container/root physically moves
+// (LiveContainer reinstalled with a new sandbox UUID, or the tweak folder relocated by
+// "convert to shared") -- reconstructing the absolute destination fresh, against whichever
+// root/scope is actually current, is exactly what this does.
+static void loadRedirectsFromDefaults(NSString *scopeFolder, NSString *scopeName, BOOL isGroupTweakFolder, NSMutableDictionary<NSString *, NSString *> *merged) {
+    NSString *udKey = isGroupTweakFolder ? @"LCDebRedirectsGroup" : @"LCDebRedirectsPrivate";
+    NSDictionary *allScopes = [NSUserDefaults.lcSharedDefaults dictionaryForKey:udKey];
+    if (![allScopes isKindOfClass:NSDictionary.class]) return;
+    NSDictionary *dict = allScopes[scopeName];
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
         if ([from isKindOfClass:NSString.class] && [to isKindOfClass:NSString.class]) {
-            merged[from] = [baseFolder stringByAppendingPathComponent:(NSString *)to];
+            merged[from] = [scopeFolder stringByAppendingPathComponent:(NSString *)to];
         }
+    }
+}
+
+// Tweaks/.lc_shared_jbroot is rebuilt from scratch on every launch (rather than persisted
+// by DebImporter at import time) directly from `merged` -- which by this point already
+// holds every currently-known redirect resolved to its real absolute path -- so it always
+// reflects exactly what's importable right now, self-healing if a tweak was added, removed,
+// or moved since the last launch, without DebImporter needing to maintain it as accumulated
+// state. Every deb-imported tweak's own ".jbroot" symlink (see DebImporter.swift's
+// createJbrootSymlink) and the extra rpath LCPatchAddRPath adds both point at this fixed
+// location, so nothing needs to be re-patched when its contents change here.
+static void rebuildSharedJbroot(NSString *globalTweakFolder, NSDictionary<NSString *, NSString *> *merged) {
+    NSFileManager *fm = NSFileManager.defaultManager;
+    NSString *sharedRoot = [globalTweakFolder stringByAppendingPathComponent:@".lc_shared_jbroot"];
+    [fm removeItemAtPath:sharedRoot error:nil];
+    [fm createDirectoryAtPath:sharedRoot withIntermediateDirectories:YES attributes:nil error:nil];
+    for (NSString *from in merged) {
+        if (![from hasPrefix:@"/"] || [from hasPrefix:@"/var/jb/"]) continue;
+        NSString *symlinkPath = [sharedRoot stringByAppendingPathComponent:from];
+        NSString *symlinkDir = symlinkPath.stringByDeletingLastPathComponent;
+        [fm createDirectoryAtPath:symlinkDir withIntermediateDirectories:YES attributes:nil error:nil];
+        [fm createSymbolicLinkAtPath:symlinkPath withDestinationPath:merged[from] error:nil];
     }
 }
 
@@ -139,15 +169,17 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 
 @end
 
-void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
+void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath, BOOL isGroupTweakFolder) {
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
-        loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], globalTweakFolder, merged);
+        loadRedirectsFromDefaults(globalTweakFolder, @"", isGroupTweakFolder, merged);
     }
     if (selectedTweakFolderPath) {
-        loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], selectedTweakFolderPath, merged);
+        loadRedirectsFromDefaults(selectedTweakFolderPath, selectedTweakFolderPath.lastPathComponent, isGroupTweakFolder, merged);
     }
     if (merged.count == 0) return;
+
+    rebuildSharedJbroot(globalTweakFolder, merged);
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];
     NSMutableArray<NSString *> *identifierKeys = [NSMutableArray new];

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -1,43 +1,8 @@
 #import "DebPathRedirect.h"
 #import "../LiveContainer/utils.h"
 #include <limits.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-// NSLog/os_log redact string arguments (both %@ and %s) as <private> by default, and no
-// syslog client available for testing could decode the {public} privacy override cleanly
-// either. Buffer every diagnostic line in memory instead, and dump it via a deliberate
-// uncaught exception a few seconds after the hooks install -- LCBootstrap.m already installs
-// NSSetUncaughtExceptionHandler and stores the exception's reason+backtrace in UserDefaults
-// under "error", which LCTabView.swift shows as a copyable crash-report sheet next time
-// LiveContainer's own UI (not the guest app) is opened. That path isn't subject to the
-// unified log's privacy redaction at all since it's just a plist value, not an os_log call.
-static NSMutableArray<NSString *> *sDiagnosticLines;
-static NSObject *sDiagnosticLock;
-static NSUInteger sDiagnosticGeneration;
-
-// Debounced: each new log line pushes the dump back another 6 seconds, so it fires 6 seconds
-// after diagnostic activity actually quiets down rather than at some arbitrary fixed point the
-// tester might not have finished navigating to by then.
-static void scheduleDiagnosticsDump(void) {
-    NSUInteger myGeneration = ++sDiagnosticGeneration;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if (myGeneration != sDiagnosticGeneration) return; // superseded by more recent activity
-        NSString *dump = [sDiagnosticLines componentsJoinedByString:@"\n"];
-        [NSException raise:@"LCDebPathRedirectDiagnostics" format:@"%@", dump];
-    });
-}
-
-static void lclog(NSString *msg) {
-    if (!sDiagnosticLock) sDiagnosticLock = [NSObject new];
-    @synchronized (sDiagnosticLock) {
-        if (!sDiagnosticLines) sDiagnosticLines = [NSMutableArray new];
-        [sDiagnosticLines addObject:msg];
-    }
-    NSLog(@"%@", msg);
-    scheduleDiagnosticsDump();
-}
 
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
 // compiled-in strings might reference (e.g. "/Library/Application Support/Foo.bundle"
@@ -58,7 +23,6 @@ static NSUInteger sIdentifierRedirectCount = 0;
 
 static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable"]);
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
@@ -77,7 +41,6 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: %s -> %s", path, buffer]);
             return buffer;
         }
     }
@@ -124,32 +87,26 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSBundle (LCDebRedirect)
 
 + (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%@]", path]);
     return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
 - (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithPath:%@]", path]);
     return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%@]", url]);
     return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
 - (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSBundle initWithURL:%@]", url]);
     return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithIdentifier:(NSString *)identifier {
     NSBundle *result = [self lc_debRedirect_bundleWithIdentifier:identifier];
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%@] -> %@", identifier, result]);
     if (result) return result;
     const char *path = lookupIdentifierRedirect(identifier.UTF8String);
     if (path) {
-        lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: bundleWithIdentifier fallback %@ -> %s", identifier, path]);
         return [NSBundle bundleWithPath:[NSString stringWithUTF8String:path]];
     }
     return result;
@@ -163,17 +120,11 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSFileManager (LCDebRedirect)
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path {
-    NSString *rewritten = lc_debRewritePath(path);
-    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten];
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@] (rewritten=%@) -> %d", path, rewritten, result]);
-    return result;
+    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path)];
 }
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path isDirectory:(BOOL *)isDirectory {
-    NSString *rewritten = lc_debRewritePath(path);
-    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten isDirectory:isDirectory];
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%@ isDirectory:] (rewritten=%@) -> %d", path, rewritten, result]);
-    return result;
+    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path) isDirectory:isDirectory];
 }
 
 - (NSArray<NSString *> *)lc_debRedirect_contentsOfDirectoryAtPath:(NSString *)path error:(NSError **)error {
@@ -183,12 +134,6 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
-    // TEMPORARY DIAGNOSTIC ONLY -- remove before merging. Scheduled unconditionally, up front,
-    // so we get a crash-report dump (see LCBootstrap.m's exceptionHandler / LCTabView's
-    // crashReportShow) of everything logged below no matter which path this function takes.
-    scheduleDiagnosticsDump();
-
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath]);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
         loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
@@ -196,7 +141,6 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     if (selectedTweakFolderPath) {
         loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
     }
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged]);
     if (merged.count == 0) return;
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];
@@ -240,5 +184,4 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     swizzle(NSFileManager.class, @selector(fileExistsAtPath:), @selector(lc_debRedirect_fileExistsAtPath:));
     swizzle(NSFileManager.class, @selector(fileExistsAtPath:isDirectory:), @selector(lc_debRedirect_fileExistsAtPath:isDirectory:));
     swizzle(NSFileManager.class, @selector(contentsOfDirectoryAtPath:error:), @selector(lc_debRedirect_contentsOfDirectoryAtPath:error:));
-    lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: installed hooks (%lu path, %lu identifier redirects)", (unsigned long)sRedirectCount, (unsigned long)sIdentifierRedirectCount]);
 }

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -5,13 +5,38 @@
 #include <stdlib.h>
 #include <string.h>
 
-// NSLog/os_log redact %@ arguments as <private> by default, and the {public} privacy
-// annotation to opt back in isn't reliably decoded by every syslog client. Side-step both
-// by doing our own string formatting first and handing NSLog the finished message through
-// a single plain %s -- no object argument left for the logging system to redact or for a
-// client to mis-decode.
+// NSLog/os_log redact string arguments (both %@ and %s) as <private> by default, and no
+// syslog client available for testing could decode the {public} privacy override cleanly
+// either. Buffer every diagnostic line in memory instead, and dump it via a deliberate
+// uncaught exception a few seconds after the hooks install -- LCBootstrap.m already installs
+// NSSetUncaughtExceptionHandler and stores the exception's reason+backtrace in UserDefaults
+// under "error", which LCTabView.swift shows as a copyable crash-report sheet next time
+// LiveContainer's own UI (not the guest app) is opened. That path isn't subject to the
+// unified log's privacy redaction at all since it's just a plist value, not an os_log call.
+static NSMutableArray<NSString *> *sDiagnosticLines;
+static NSObject *sDiagnosticLock;
+static NSUInteger sDiagnosticGeneration;
+
+// Debounced: each new log line pushes the dump back another 6 seconds, so it fires 6 seconds
+// after diagnostic activity actually quiets down rather than at some arbitrary fixed point the
+// tester might not have finished navigating to by then.
+static void scheduleDiagnosticsDump(void) {
+    NSUInteger myGeneration = ++sDiagnosticGeneration;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        if (myGeneration != sDiagnosticGeneration) return; // superseded by more recent activity
+        NSString *dump = [sDiagnosticLines componentsJoinedByString:@"\n"];
+        [NSException raise:@"LCDebPathRedirectDiagnostics" format:@"%@", dump];
+    });
+}
+
 static void lclog(NSString *msg) {
-    NSLog(@"%{public}s", msg.UTF8String);
+    if (!sDiagnosticLock) sDiagnosticLock = [NSObject new];
+    @synchronized (sDiagnosticLock) {
+        if (!sDiagnosticLines) sDiagnosticLines = [NSMutableArray new];
+        [sDiagnosticLines addObject:msg];
+    }
+    NSLog(@"%@", msg);
+    scheduleDiagnosticsDump();
 }
 
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
@@ -52,7 +77,7 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            NSLog(@"[LC] DebPathRedirect: %{public}s -> %{public}s", path, buffer);
+            lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: %s -> %s", path, buffer]);
             return buffer;
         }
     }
@@ -158,6 +183,11 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
+    // TEMPORARY DIAGNOSTIC ONLY -- remove before merging. Scheduled unconditionally, up front,
+    // so we get a crash-report dump (see LCBootstrap.m's exceptionHandler / LCTabView's
+    // crashReportShow) of everything logged below no matter which path this function takes.
+    scheduleDiagnosticsDump();
+
     lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath]);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -7,7 +7,9 @@
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
 // compiled-in strings might reference (e.g. "/Library/Application Support/Foo.bundle"
 // or "/var/jb/Library/Frameworks/Foo.framework") to where DebImporter.swift actually
-// put that resource inside the LiveContainer tweak folder.
+// put that resource inside the LiveContainer tweak folder. Path keys start with "/";
+// entries prefixed "id:" instead map a bundle's own CFBundleIdentifier to its path, for
+// tweaks that look their bundle up by identifier rather than by path.
 typedef struct {
     char *from;
     size_t fromLen;
@@ -16,9 +18,12 @@ typedef struct {
 
 static LCDebRedirect *sRedirects = NULL;
 static NSUInteger sRedirectCount = 0;
+static LCDebRedirect *sIdentifierRedirects = NULL;
+static NSUInteger sIdentifierRedirectCount = 0;
 
 static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
+    NSLog(@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable");
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
@@ -37,10 +42,21 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
+            NSLog(@"[LC] DebPathRedirect: %s -> %s", path, buffer);
             return buffer;
         }
     }
     return path;
+}
+
+static const char *lookupIdentifierRedirect(const char *identifier) {
+    if (!identifier) return NULL;
+    for (NSUInteger i = 0; i < sIdentifierRedirectCount; i++) {
+        if (strcmp(identifier, sIdentifierRedirects[i].from) == 0) {
+            return sIdentifierRedirects[i].to;
+        }
+    }
+    return NULL;
 }
 
 // NSBundle/CFBundle and NSFileManager do their actual filesystem work (stat/open) from
@@ -73,19 +89,35 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSBundle (LCDebRedirect)
 
 + (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
+    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%@]", path);
     return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
 - (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
+    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithPath:%@]", path);
     return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
+    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%@]", url);
     return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
 - (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
+    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithURL:%@]", url);
     return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
+}
+
++ (instancetype)lc_debRedirect_bundleWithIdentifier:(NSString *)identifier {
+    NSBundle *result = [self lc_debRedirect_bundleWithIdentifier:identifier];
+    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%@] -> %@", identifier, result);
+    if (result) return result;
+    const char *path = lookupIdentifierRedirect(identifier.UTF8String);
+    if (path) {
+        NSLog(@"[LC] DebPathRedirect: bundleWithIdentifier fallback %@ -> %s", identifier, path);
+        return [NSBundle bundleWithPath:[NSString stringWithUTF8String:path]];
+    }
+    return result;
 }
 
 @end
@@ -110,6 +142,7 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
+    NSLog(@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
         loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
@@ -117,28 +150,49 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     if (selectedTweakFolderPath) {
         loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
     }
+    NSLog(@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged);
     if (merged.count == 0) return;
 
-    sRedirectCount = merged.count;
+    NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];
+    NSMutableArray<NSString *> *identifierKeys = [NSMutableArray new];
+    for (NSString *key in merged) {
+        if ([key hasPrefix:@"id:"]) {
+            [identifierKeys addObject:key];
+        } else {
+            [pathKeys addObject:key];
+        }
+    }
+
+    sRedirectCount = pathKeys.count;
     sRedirects = calloc(sRedirectCount, sizeof(LCDebRedirect));
-    NSUInteger i = 0;
-    for (NSString *from in merged) {
+    for (NSUInteger i = 0; i < pathKeys.count; i++) {
+        NSString *from = pathKeys[i];
         sRedirects[i].from = strdup(from.fileSystemRepresentation);
         sRedirects[i].fromLen = strlen(sRedirects[i].from);
         sRedirects[i].to = strdup(merged[from].fileSystemRepresentation);
-        i++;
     }
     // longest (most specific) prefix first, so a nested path never matches a shorter parent by accident
     qsort_b(sRedirects, sRedirectCount, sizeof(LCDebRedirect), ^int(const void *a, const void *b) {
         return (int)(((const LCDebRedirect *)b)->fromLen - ((const LCDebRedirect *)a)->fromLen);
     });
 
+    sIdentifierRedirectCount = identifierKeys.count;
+    sIdentifierRedirects = calloc(sIdentifierRedirectCount, sizeof(LCDebRedirect));
+    for (NSUInteger i = 0; i < identifierKeys.count; i++) {
+        NSString *key = identifierKeys[i];
+        NSString *identifier = [key substringFromIndex:3];
+        sIdentifierRedirects[i].from = strdup(identifier.UTF8String);
+        sIdentifierRedirects[i].to = strdup(merged[key].fileSystemRepresentation);
+    }
+
     swizzleClassMethod(NSBundle.class, @selector(bundleWithPath:), @selector(lc_debRedirect_bundleWithPath:));
     swizzle(NSBundle.class, @selector(initWithPath:), @selector(lc_debRedirect_initWithPath:));
     swizzleClassMethod(NSBundle.class, @selector(bundleWithURL:), @selector(lc_debRedirect_bundleWithURL:));
     swizzle(NSBundle.class, @selector(initWithURL:), @selector(lc_debRedirect_initWithURL:));
+    swizzleClassMethod(NSBundle.class, @selector(bundleWithIdentifier:), @selector(lc_debRedirect_bundleWithIdentifier:));
 
     swizzle(NSFileManager.class, @selector(fileExistsAtPath:), @selector(lc_debRedirect_fileExistsAtPath:));
     swizzle(NSFileManager.class, @selector(fileExistsAtPath:isDirectory:), @selector(lc_debRedirect_fileExistsAtPath:isDirectory:));
     swizzle(NSFileManager.class, @selector(contentsOfDirectoryAtPath:error:), @selector(lc_debRedirect_contentsOfDirectoryAtPath:error:));
+    NSLog(@"[LC] DebPathRedirect: installed hooks (%lu path, %lu identifier redirects)", (unsigned long)sRedirectCount, (unsigned long)sIdentifierRedirectCount);
 }

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -6,12 +6,12 @@
 #include <string.h>
 
 // NSLog/os_log redact %@ arguments as <private> by default, and the {public} privacy
-// annotation isn't reliably decoded by every syslog client -- write diagnostics straight
-// to stderr instead, which the system captures into the unified log verbatim, unredacted,
-// with no format-string decoding involved.
+// annotation to opt back in isn't reliably decoded by every syslog client. Side-step both
+// by doing our own string formatting first and handing NSLog the finished message through
+// a single plain %s -- no object argument left for the logging system to redact or for a
+// client to mis-decode.
 static void lclog(NSString *msg) {
-    fprintf(stderr, "%s\n", msg.UTF8String);
-    fflush(stderr);
+    NSLog(@"%s", msg.UTF8String);
 }
 
 // Redirect table: each entry maps an absolute path prefix a deb-imported tweak's
@@ -52,8 +52,7 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            fprintf(stderr, "[LC] DebPathRedirect: %s -> %s\n", path, buffer);
-            fflush(stderr);
+            NSLog(@"[LC] DebPathRedirect: %s -> %s", path, buffer);
             return buffer;
         }
     }

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -51,14 +51,20 @@ static void lclog(NSString *msg) {
     scheduleDiagnosticsDump();
 }
 
-static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
+// Values in the plist are stored relative to baseFolder (the tweak-folder root the plist
+// itself lives in), not as absolute paths -- that root can move (LiveContainer reinstalled
+// with a new sandbox container UUID, or the tweak folder relocated by "convert to shared"),
+// so the absolute destination is reconstructed fresh against whichever root is current at
+// each launch instead of being baked in at import time. See DebImporter.swift for the write
+// side of this.
+static void loadRedirectsFromPlist(NSString *plistPath, NSString *baseFolder, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
     lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable"]);
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
         if ([from isKindOfClass:NSString.class] && [to isKindOfClass:NSString.class]) {
-            merged[from] = to;
+            merged[from] = [baseFolder stringByAppendingPathComponent:(NSString *)to];
         }
     }
 }
@@ -189,10 +195,10 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath]);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
-        loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
+        loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], globalTweakFolder, merged);
     }
     if (selectedTweakFolderPath) {
-        loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
+        loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], selectedTweakFolderPath, merged);
     }
     lclog([NSString stringWithFormat:@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged]);
     if (merged.count == 0) return;

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -23,7 +23,7 @@ static NSUInteger sIdentifierRedirectCount = 0;
 
 static void loadRedirectsFromPlist(NSString *plistPath, NSMutableDictionary<NSString *, NSString *> *merged) {
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
-    NSLog(@"[LC] DebPathRedirect: reading %@ -> %@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable");
+    NSLog(@"[LC] DebPathRedirect: reading %{public}@ -> %{public}@ entries", plistPath, dict ? @(dict.count) : @"none/unreadable");
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
@@ -42,7 +42,7 @@ static const char *rewritePath(const char *path) {
             (path[r->fromLen] == '\0' || path[r->fromLen] == '/')) {
             static __thread char buffer[PATH_MAX];
             snprintf(buffer, sizeof(buffer), "%s%s", r->to, path + r->fromLen);
-            NSLog(@"[LC] DebPathRedirect: %s -> %s", path, buffer);
+            NSLog(@"[LC] DebPathRedirect: %{public}s -> %{public}s", path, buffer);
             return buffer;
         }
     }
@@ -89,32 +89,32 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSBundle (LCDebRedirect)
 
 + (instancetype)lc_debRedirect_bundleWithPath:(NSString *)path {
-    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%@]", path);
+    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithPath:%{public}@]", path);
     return [self lc_debRedirect_bundleWithPath:lc_debRewritePath(path)];
 }
 
 - (instancetype)lc_debRedirect_initWithPath:(NSString *)path {
-    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithPath:%@]", path);
+    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithPath:%{public}@]", path);
     return [self lc_debRedirect_initWithPath:lc_debRewritePath(path)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithURL:(NSURL *)url {
-    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%@]", url);
+    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithURL:%{public}@]", url);
     return [self lc_debRedirect_bundleWithURL:lc_debRewriteFileURL(url)];
 }
 
 - (instancetype)lc_debRedirect_initWithURL:(NSURL *)url {
-    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithURL:%@]", url);
+    NSLog(@"[LC] DebPathRedirect: -[NSBundle initWithURL:%{public}@]", url);
     return [self lc_debRedirect_initWithURL:lc_debRewriteFileURL(url)];
 }
 
 + (instancetype)lc_debRedirect_bundleWithIdentifier:(NSString *)identifier {
     NSBundle *result = [self lc_debRedirect_bundleWithIdentifier:identifier];
-    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%@] -> %@", identifier, result);
+    NSLog(@"[LC] DebPathRedirect: +[NSBundle bundleWithIdentifier:%{public}@] -> %{public}@", identifier, result);
     if (result) return result;
     const char *path = lookupIdentifierRedirect(identifier.UTF8String);
     if (path) {
-        NSLog(@"[LC] DebPathRedirect: bundleWithIdentifier fallback %@ -> %s", identifier, path);
+        NSLog(@"[LC] DebPathRedirect: bundleWithIdentifier fallback %{public}@ -> %{public}s", identifier, path);
         return [NSBundle bundleWithPath:[NSString stringWithUTF8String:path]];
     }
     return result;
@@ -128,11 +128,17 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @implementation NSFileManager (LCDebRedirect)
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path {
-    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path)];
+    NSString *rewritten = lc_debRewritePath(path);
+    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten];
+    NSLog(@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%{public}@] (rewritten=%{public}@) -> %d", path, rewritten, result);
+    return result;
 }
 
 - (BOOL)lc_debRedirect_fileExistsAtPath:(NSString *)path isDirectory:(BOOL *)isDirectory {
-    return [self lc_debRedirect_fileExistsAtPath:lc_debRewritePath(path) isDirectory:isDirectory];
+    NSString *rewritten = lc_debRewritePath(path);
+    BOOL result = [self lc_debRedirect_fileExistsAtPath:rewritten isDirectory:isDirectory];
+    NSLog(@"[LC] DebPathRedirect: -[NSFileManager fileExistsAtPath:%{public}@ isDirectory:] (rewritten=%{public}@) -> %d", path, rewritten, result);
+    return result;
 }
 
 - (NSArray<NSString *> *)lc_debRedirect_contentsOfDirectoryAtPath:(NSString *)path error:(NSError **)error {
@@ -142,7 +148,7 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 @end
 
 void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
-    NSLog(@"[LC] DebPathRedirect: init globalTweakFolder=%@ selectedTweakFolderPath=%@", globalTweakFolder, selectedTweakFolderPath);
+    NSLog(@"[LC] DebPathRedirect: init globalTweakFolder=%{public}@ selectedTweakFolderPath=%{public}@", globalTweakFolder, selectedTweakFolderPath);
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
         loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
@@ -150,7 +156,7 @@ void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFol
     if (selectedTweakFolderPath) {
         loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], merged);
     }
-    NSLog(@"[LC] DebPathRedirect: merged %lu entries: %@", (unsigned long)merged.count, merged);
+    NSLog(@"[LC] DebPathRedirect: merged %lu entries: %{public}@", (unsigned long)merged.count, merged);
     if (merged.count == 0) return;
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];

--- a/TweakLoader/DebPathRedirect.m
+++ b/TweakLoader/DebPathRedirect.m
@@ -21,50 +21,20 @@ static NSUInteger sRedirectCount = 0;
 static LCDebRedirect *sIdentifierRedirects = NULL;
 static NSUInteger sIdentifierRedirectCount = 0;
 
-// Redirect data lives in NSUserDefaults (the App Group suite this codebase already uses
-// for every other piece of persistent LiveContainer config) rather than a dotfile inside
-// the user-browsable Tweaks folder. DebImporter.swift writes one top-level key per
-// physical tweak-folder root (isGroupTweakFolder picks which), holding a dictionary of
-// scopes -- "" for the root's own (global) entries, or a per-app-selected folder's name --
-// each mapping a bare absolute path to a path *relative to that scope's own folder*. That
-// relative storage (rather than an absolute path baked in at import time) is what lets the
-// same entry keep resolving correctly however the container/root physically moves
-// (LiveContainer reinstalled with a new sandbox UUID, or the tweak folder relocated by
-// "convert to shared") -- reconstructing the absolute destination fresh, against whichever
-// root/scope is actually current, is exactly what this does.
-static void loadRedirectsFromDefaults(NSString *scopeFolder, NSString *scopeName, BOOL isGroupTweakFolder, NSMutableDictionary<NSString *, NSString *> *merged) {
-    NSString *udKey = isGroupTweakFolder ? @"LCDebRedirectsGroup" : @"LCDebRedirectsPrivate";
-    NSDictionary *allScopes = [NSUserDefaults.lcSharedDefaults dictionaryForKey:udKey];
-    if (![allScopes isKindOfClass:NSDictionary.class]) return;
-    NSDictionary *dict = allScopes[scopeName];
+// Values in the plist are stored relative to baseFolder (the tweak-folder root the plist
+// itself lives in), not as absolute paths -- that root can move (LiveContainer reinstalled
+// with a new sandbox container UUID, or the tweak folder relocated by "convert to shared"),
+// so the absolute destination is reconstructed fresh against whichever root is current at
+// each launch instead of being baked in at import time. See DebImporter.swift for the write
+// side of this.
+static void loadRedirectsFromPlist(NSString *plistPath, NSString *baseFolder, NSMutableDictionary<NSString *, NSString *> *merged) {
+    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile:plistPath];
     if (![dict isKindOfClass:NSDictionary.class]) return;
     for (NSString *from in dict) {
         id to = dict[from];
         if ([from isKindOfClass:NSString.class] && [to isKindOfClass:NSString.class]) {
-            merged[from] = [scopeFolder stringByAppendingPathComponent:(NSString *)to];
+            merged[from] = [baseFolder stringByAppendingPathComponent:(NSString *)to];
         }
-    }
-}
-
-// Tweaks/.lc_shared_jbroot is rebuilt from scratch on every launch (rather than persisted
-// by DebImporter at import time) directly from `merged` -- which by this point already
-// holds every currently-known redirect resolved to its real absolute path -- so it always
-// reflects exactly what's importable right now, self-healing if a tweak was added, removed,
-// or moved since the last launch, without DebImporter needing to maintain it as accumulated
-// state. Every deb-imported tweak's own ".jbroot" symlink (see DebImporter.swift's
-// createJbrootSymlink) and the extra rpath LCPatchAddRPath adds both point at this fixed
-// location, so nothing needs to be re-patched when its contents change here.
-static void rebuildSharedJbroot(NSString *globalTweakFolder, NSDictionary<NSString *, NSString *> *merged) {
-    NSFileManager *fm = NSFileManager.defaultManager;
-    NSString *sharedRoot = [globalTweakFolder stringByAppendingPathComponent:@".lc_shared_jbroot"];
-    [fm removeItemAtPath:sharedRoot error:nil];
-    [fm createDirectoryAtPath:sharedRoot withIntermediateDirectories:YES attributes:nil error:nil];
-    for (NSString *from in merged) {
-        if (![from hasPrefix:@"/"] || [from hasPrefix:@"/var/jb/"]) continue;
-        NSString *symlinkPath = [sharedRoot stringByAppendingPathComponent:from];
-        NSString *symlinkDir = symlinkPath.stringByDeletingLastPathComponent;
-        [fm createDirectoryAtPath:symlinkDir withIntermediateDirectories:YES attributes:nil error:nil];
-        [fm createSymbolicLinkAtPath:symlinkPath withDestinationPath:merged[from] error:nil];
     }
 }
 
@@ -169,17 +139,15 @@ static NSURL *lc_debRewriteFileURL(NSURL *url) {
 
 @end
 
-void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath, BOOL isGroupTweakFolder) {
+void DebPathRedirectInit(NSString *globalTweakFolder, NSString *selectedTweakFolderPath) {
     NSMutableDictionary<NSString *, NSString *> *merged = [NSMutableDictionary new];
     if (globalTweakFolder) {
-        loadRedirectsFromDefaults(globalTweakFolder, @"", isGroupTweakFolder, merged);
+        loadRedirectsFromPlist([globalTweakFolder stringByAppendingPathComponent:@".lc_deb_redirects.plist"], globalTweakFolder, merged);
     }
     if (selectedTweakFolderPath) {
-        loadRedirectsFromDefaults(selectedTweakFolderPath, selectedTweakFolderPath.lastPathComponent, isGroupTweakFolder, merged);
+        loadRedirectsFromPlist([selectedTweakFolderPath stringByAppendingPathComponent:@".lc_deb_redirects.plist"], selectedTweakFolderPath, merged);
     }
     if (merged.count == 0) return;
-
-    rebuildSharedJbroot(globalTweakFolder, merged);
 
     NSMutableArray<NSString *> *pathKeys = [NSMutableArray new];
     NSMutableArray<NSString *> *identifierKeys = [NSMutableArray new];

--- a/TweakLoader/TweakLoader.m
+++ b/TweakLoader/TweakLoader.m
@@ -92,7 +92,7 @@ static void TweakLoaderConstructor() {
     NSMutableArray *errors = [NSMutableArray new];
     
     NSArray<NSURL *> *globalTweaks = [NSFileManager.defaultManager contentsOfDirectoryAtURL:[NSURL fileURLWithPath:globalTweakFolder]
-    includingPropertiesForKeys:@[] options:0 error:nil];
+    includingPropertiesForKeys:@[NSURLIsDirectoryKey] options:0 error:nil];
     NSString *tweakFolderName = NSUserDefaults.guestAppInfo[@"LCTweakFolder"];
     
     if([globalTweaks count] <= 1 && tweakFolderName.length == 0) {
@@ -134,9 +134,18 @@ static void TweakLoaderConstructor() {
             NSLog(@"Skipping disabled global tweak %@", name);
             continue;
         }
-        NSString *error = loadTweakAtURL(fileURL);
-        if (error) {
-            [errors addObject:error];
+        NSNumber *isDirectory = nil;
+        [fileURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
+        // a deb-imported tweak lands in its own plain subfolder (mirroring its original
+        // layout) rather than as a loose .dylib/.framework, so recurse into it the same
+        // way the selected per-app tweak folder already does below.
+        if (isDirectory.boolValue && ![name hasSuffix:@".framework"]) {
+            loadTweaksRecursively(fileURL, errors);
+        } else {
+            NSString *error = loadTweakAtURL(fileURL);
+            if (error) {
+                [errors addObject:error];
+            }
         }
     }
 

--- a/TweakLoader/TweakLoader.m
+++ b/TweakLoader/TweakLoader.m
@@ -36,7 +36,13 @@ static NSString *loadTweakAtURL(NSURL *url) {
 }
 
 static void loadTweaksRecursively(NSURL *folderURL, NSMutableArray *errors) {
-    NSArray<NSURL *> *items = [NSFileManager.defaultManager contentsOfDirectoryAtURL:folderURL includingPropertiesForKeys:@[NSURLIsDirectoryKey] options:0 error:nil];
+    // Skip dotfiles -- in particular ".jbroot", the symlink DebImporter.swift places next to
+    // every deb-imported dylib/framework pointing at Tweaks/.lc_shared_jbroot. Since
+    // NSURLIsDirectoryKey follows symlinks, a symlink-to-directory reports YES there, so
+    // without this we'd recurse into .lc_shared_jbroot itself and re-dlopen every mirrored
+    // framework from every other currently-imported tweak a second time through it (and
+    // surface a bogus "Failed to load tweaks" error for any mirror entry that's gone stale).
+    NSArray<NSURL *> *items = [NSFileManager.defaultManager contentsOfDirectoryAtURL:folderURL includingPropertiesForKeys:@[NSURLIsDirectoryKey] options:NSDirectoryEnumerationSkipsHiddenFiles error:nil];
     for (NSURL *fileURL in items) {
         NSString *name = fileURL.lastPathComponent;
         if ([name hasSuffix:@".disabled"]) {

--- a/TweakLoader/TweakLoader.m
+++ b/TweakLoader/TweakLoader.m
@@ -3,6 +3,7 @@
 #include <dlfcn.h>
 #include <objc/runtime.h>
 #import "../LiveContainer/utils.h"
+#import "DebPathRedirect.h"
 
 static NSString *loadTweakAtURL(NSURL *url) {
     NSString *tweakPath = url.path;
@@ -98,6 +99,12 @@ static void TweakLoaderConstructor() {
         // nothing to load
         return;
     }
+
+    // Rewrite the absolute paths deb-imported tweaks use to find their own bundles/frameworks
+    // (e.g. /Library/Application Support/Foo.bundle) to wherever DebImporter actually put them,
+    // before any tweak dylib is dlopen'd and can go looking for them.
+    NSString *selectedTweakFolderPath = tweakFolderName.length > 0 ? [globalTweakFolder stringByAppendingPathComponent:tweakFolderName] : nil;
+    DebPathRedirectInit(globalTweakFolder, selectedTweakFolderPath);
 
     // Load CydiaSubstrate
     const char *lcMainBundlePath;

--- a/TweakLoader/TweakLoader.m
+++ b/TweakLoader/TweakLoader.m
@@ -2,7 +2,6 @@
 #import <UIKit/UIKit.h>
 #include <dlfcn.h>
 #include <objc/runtime.h>
-#include <string.h>
 #import "../LiveContainer/utils.h"
 #import "DebPathRedirect.h"
 
@@ -83,8 +82,6 @@ static void TweakLoaderConstructor() {
     const char *tweakFolderC = getenv("LC_GLOBAL_TWEAKS_FOLDER");
     NSString *globalTweakFolder = @(tweakFolderC);
     unsetenv("LC_GLOBAL_TWEAKS_FOLDER");
-    BOOL isGroupTweakFolder = getenv("LC_GLOBAL_TWEAKS_IS_GROUP") && !strcmp(getenv("LC_GLOBAL_TWEAKS_IS_GROUP"), "1");
-    unsetenv("LC_GLOBAL_TWEAKS_IS_GROUP");
     
     if([NSUserDefaults.guestAppInfo[@"dontInjectTweakLoader"] boolValue]) {
         // don't load any tweak since tweakloader is loaded after all initializers
@@ -107,7 +104,7 @@ static void TweakLoaderConstructor() {
     // (e.g. /Library/Application Support/Foo.bundle) to wherever DebImporter actually put them,
     // before any tweak dylib is dlopen'd and can go looking for them.
     NSString *selectedTweakFolderPath = tweakFolderName.length > 0 ? [globalTweakFolder stringByAppendingPathComponent:tweakFolderName] : nil;
-    DebPathRedirectInit(globalTweakFolder, selectedTweakFolderPath, isGroupTweakFolder);
+    DebPathRedirectInit(globalTweakFolder, selectedTweakFolderPath);
 
     // Load CydiaSubstrate
     const char *lcMainBundlePath;

--- a/TweakLoader/TweakLoader.m
+++ b/TweakLoader/TweakLoader.m
@@ -2,6 +2,7 @@
 #import <UIKit/UIKit.h>
 #include <dlfcn.h>
 #include <objc/runtime.h>
+#include <string.h>
 #import "../LiveContainer/utils.h"
 #import "DebPathRedirect.h"
 
@@ -82,6 +83,8 @@ static void TweakLoaderConstructor() {
     const char *tweakFolderC = getenv("LC_GLOBAL_TWEAKS_FOLDER");
     NSString *globalTweakFolder = @(tweakFolderC);
     unsetenv("LC_GLOBAL_TWEAKS_FOLDER");
+    BOOL isGroupTweakFolder = getenv("LC_GLOBAL_TWEAKS_IS_GROUP") && !strcmp(getenv("LC_GLOBAL_TWEAKS_IS_GROUP"), "1");
+    unsetenv("LC_GLOBAL_TWEAKS_IS_GROUP");
     
     if([NSUserDefaults.guestAppInfo[@"dontInjectTweakLoader"] boolValue]) {
         // don't load any tweak since tweakloader is loaded after all initializers
@@ -104,7 +107,7 @@ static void TweakLoaderConstructor() {
     // (e.g. /Library/Application Support/Foo.bundle) to wherever DebImporter actually put them,
     // before any tweak dylib is dlopen'd and can go looking for them.
     NSString *selectedTweakFolderPath = tweakFolderName.length > 0 ? [globalTweakFolder stringByAppendingPathComponent:tweakFolderName] : nil;
-    DebPathRedirectInit(globalTweakFolder, selectedTweakFolderPath);
+    DebPathRedirectInit(globalTweakFolder, selectedTweakFolderPath, isGroupTweakFolder);
 
     // Load CydiaSubstrate
     const char *lcMainBundlePath;

--- a/TweakLoader/TweakLoader.m
+++ b/TweakLoader/TweakLoader.m
@@ -136,11 +136,20 @@ static void TweakLoaderConstructor() {
         }
         NSNumber *isDirectory = nil;
         [fileURL getResourceValue:&isDirectory forKey:NSURLIsDirectoryKey error:nil];
-        // a deb-imported tweak lands in its own plain subfolder (mirroring its original
-        // layout) rather than as a loose .dylib/.framework, so recurse into it the same
-        // way the selected per-app tweak folder already does below.
         if (isDirectory.boolValue && ![name hasSuffix:@".framework"]) {
-            loadTweaksRecursively(fileURL, errors);
+            // A plain folder sitting directly in the global tweaks root is either a
+            // deb-imported tweak's own folder (mirroring its original directory layout,
+            // marked with ".lc_deb_tweak" by DebImporter.swift) or a folder the user
+            // created themselves to group/select tweaks per-app (which may itself
+            // contain nested deb-imported tweaks). Only the former should behave like a
+            // loose .dylib here and load for every app; the latter is loaded, scoped
+            // correctly, by "Load selected tweak folder" below, only for an app that
+            // actually selected it -- loading it here too would inject it into every
+            // app regardless of selection, which is the whole point of that mechanism.
+            NSString *markerPath = [fileURL URLByAppendingPathComponent:@".lc_deb_tweak"].path;
+            if ([NSFileManager.defaultManager fileExistsAtPath:markerPath]) {
+                loadTweaksRecursively(fileURL, errors);
+            }
         } else {
             NSString *error = loadTweakAtURL(fileURL);
             if (error) {


### PR DESCRIPTION
This pull request introduces support for importing rootless jailbreak `.deb` tweak packages into LiveContainer, alongside several related improvements. The changes add a new Swift utility for handling `.deb` extraction, safe control script interpretation, payload installation, and resource redirection. Additionally, the codebase is updated to handle new tweak folder conventions and shared resource resolution.

**Debian Tweak Import Support and Resource Resolution Improvements:**

*Debian Package Import and Processing:*
- Added a new utility `DebImporter.swift` that imports `.deb` tweak packages by extracting their contents, interpreting a safe subset of pre/post-install scripts, mirroring payloads into tweak folders, patching Mach-O rpaths, and maintaining resource redirects and symlinks for correct runtime behavior. This includes logic for handling both same-package and cross-package dependencies via a shared resource mirror (`.lc_shared_jbroot`).

*Mach-O rpath Handling:*
- Updated `LCPatchAddRPath` in `LCMachOUtils.m` to add an rpath for the shared resource mirror (`@executable_path/../../Tweaks/.lc_shared_jbroot`), ensuring tweaks can resolve dependencies installed by other packages.

*File and Folder Handling:*
- Improved tweak folder scanning to skip DebImporter bookkeeping files (e.g., `.lc_deb_redirects.plist`, `.lc_shared_jbroot`) during directory traversal, preventing accidental processing of internal data as tweaks.

*Signing Logic:*
- Refactored code signature checks to recursively process subfolders, ensuring all nested dylibs and frameworks in both manually-organized and deb-imported tweak folders are signed as needed.

*Project Configuration:*
- Added `DebPathRedirect.m` to the Xcode project file, enabling its use for path redirection in support of the new deb-imported tweak handling.

*Testing*
- Tested with the `EeveeSpotify` tweak for Spotify (correctly uses bundled frameworks included with the tweak, as well as `Orion` standalone dependency), `SCInsta` tweak for Instagram, and `YouMod` tweak for Youtube (correctly uses bundled resource files, like languages, icons, etc)

<sub>With help from Claude Code</sub>